### PR TITLE
fix(rlm): child context inheritance (#4) + EPIPE crash on dead worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ implementation of `llm_query` / `llm_query_batched` / `rlm_query` / `rlm_query_b
 
 5. **The subcall emit pattern** (create → execute → update status/cost/tokens) — the `emitting()` helper in `subcall-handlers.ts` for leaf sub-calls; `childRun` emits its own node for recursive ones (never wrap it, or the node is reported twice). `interactive.ts` follows the same shape by hand. Adding a new subcall handler? Reuse these — don't invent a new pattern.
 
+6. **Child context inheritance** — `getChildContext` on `SubcallHandlerDeps` is the ONE seam by
+   which a child RLM receives its parent's world (repo pack + loaded libraries). `childRun` is the
+   only place an `RlmInput` for a child is constructed. A second path here is how issue #4
+   happened: whichever path forgets to grow leaves the child blind, and it degrades silently.
+
 **Callers differ only in `resolve`.** The engine binds one `Invocation` for a whole run; the
 repl() tool swaps one per turn and routes `spawn()`ed (detached) work to the session-scoped
 `BackgroundTasks` registry. If you find yourself adding a second construction path, add a

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ sub-LLM calls, hence the name.
 
 - A **root orchestrator** model drives a **persistent Python REPL** turn-by-turn.
 - Long-context work is **delegated** to cheap worker models via `llm_query` / `llm_query_batched`.
-- Hard sub-problems **recurse** into child RLMs via `rlm_query` (depth-capped).
+- Hard sub-problems **recurse** into child RLMs via `rlm_query` (depth-capped). A child inherits
+  its parent's `context` — the repository plus every library loaded with `load_library()` — so it
+  runs the same retrieval primitives over the same paths. Inheritance costs no extra tokens: the
+  content lives in the sandbox, and only a size line reaches the model.
 - Everything runs **in-process** — the only external process is one local `python3` worker.
 
 > This is a Pi-plugin reimplementation of the RLM method (see the [RLM paper](https://arxiv.org/abs/2512.24601)).
@@ -118,8 +121,8 @@ These functions are injected into the model's Python namespace inside the REPL:
 | `context` | `list[dict]` | Repository packed as `[{"path","content","tokens"}, ...]` — the full codebase |
 | `llm_query` | `(prompt, model=None) -> str` | One-shot sub-LLM call (worker model) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | Concurrent sub-LLM calls (pool-bounded) |
-| `rlm_query` | `(prompt, model=None) -> str` | Recursive child RLM with its own sandbox (depth-capped) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | Concurrent recursive child RLMs |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | Recursive child RLM with its own sandbox (depth-capped). Inherits your `context`; `paths` narrows it by prefix |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | Concurrent recursive child RLMs, sharing one `paths` slice |
 | `todo` | `(action, **kwargs) -> str` | Task list: `create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | Ask the user structured questions (depth 0 only) |
 | `stage_edit` | `(path, old_text, new_text) -> str` | Stage a file edit; relayed to the host's native edit flow |

--- a/README.ru.md
+++ b/README.ru.md
@@ -34,6 +34,9 @@
 - **Модель-оркестратор** управляет постоянным Python REPL пошагово.
 - Работа с длинным контекстом **делегируется** дешевым worker-моделям через `llm_query` / `llm_query_batched`.
 - Сложные подзадачи **рекурсивно** передаются в дочерние RLM через `rlm_query` (с ограничением глубины).
+  Дочерний RLM наследует `context` родителя — репозиторий и все библиотеки, загруженные через
+  `load_library()`, — и работает с теми же путями. Наследование не стоит дополнительных токенов:
+  содержимое живёт в песочнице, модель видит только строку с размером.
 - Все работает **in-process** — единственным внешним процессом является локальный worker `python3`.
 
 > This is a Pi-plugin reimplementation of the RLM method (see the [RLM paper](https://arxiv.org/abs/2512.24601)).
@@ -106,8 +109,8 @@ rm -rf ~/.pi/agent/extensions/rlm
 | `context` | `list[dict]` | Репозиторий, упакованный как `[{"path","content","tokens"}, ...]` — вся кодовая база |
 | `llm_query` | `(prompt, model=None) -> str` | Одноразовый вызов sub-LLM (worker-модель) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | Параллельные вызовы sub-LLM (с ограничением пула) |
-| `rlm_query` | `(prompt, model=None) -> str` | Рекурсивный дочерний RLM со своей песочницей (с ограничением глубины) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | Параллельные рекурсивные дочерние RLM |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | Рекурсивный дочерний RLM со своей песочницей (с ограничением глубины). Наследует ваш `context`; `paths` сужает его по префиксу |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | Параллельные рекурсивные дочерние RLM с общим срезом `paths` |
 | `todo` | `(action, **kwargs) -> str` | Список задач: `create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | Задать пользователю структурированные вопросы (только на глубине 0) |
 | `SHOW_VARS` | `() -> str` | Список текущих переменных и их типов |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,7 +33,9 @@
 
 - **根编排器**模型逐轮驱动一个**持久化的 Python REPL**。
 - 长上下文工作通过 `llm_query` / `llm_query_batched` **委派**给廉价的工作模型。
-- 困难的子问题通过 `rlm_query` **递归**到子 RLM 中（设有深度限制）。
+- 困难的子问题通过 `rlm_query` **递归**到子 RLM 中（设有深度限制）。子 RLM 继承父级的 `context`
+  ——仓库以及通过 `load_library()` 加载的所有库——因此可以在相同的路径上使用相同的检索原语。
+  继承不消耗额外的 token：内容存放在沙箱中，模型只看到一行大小信息。
 - 所有内容均**在进程内**运行 —— 唯一的外部进程是一个本地的 `python3` worker。
 
 > 这是 RLM 方法的 Pi 插件重新实现（参见 [RLM 论文](https://arxiv.org/abs/2512.24601)）。
@@ -113,8 +115,8 @@ rm -rf ~/.pi/agent/extensions/rlm
 | `context` | `list[dict]` | 打包为 `[{"path","content","tokens"}, ...]` 的仓库 —— 完整的代码库 |
 | `llm_query` | `(prompt, model=None) -> str` | 单次子 LLM 调用 (worker 模型) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | 并发子 LLM 调用 (池上限) |
-| `rlm_query` | `(prompt, model=None) -> str` | 具有自有沙箱的递归子 RLM (设有深度限制) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | 并发递归子 RLM |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | 具有自有沙箱的递归子 RLM (设有深度限制)。继承父级的 `context`；`paths` 按前缀缩小范围 |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | 并发递归子 RLM，共享同一个 `paths` 切片 |
 | `todo` | `(action, **kwargs) -> str` | 任务列表：`create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | 向用户提出结构化问题 (仅限深度 0) |
 | `SHOW_VARS` | `() -> str` | 列出当前定义的变量及其类型 |

--- a/pi-plugin/rlm/CHANGELOG.md
+++ b/pi-plugin/rlm/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A dying Python worker could take the whole pi session down.** `PythonSandbox` attached
+  listeners to the child process and to stdout/stderr, but never to `proc.stdin`. A write to a
+  dead worker's pipe fails *asynchronously* — node emits `'error'` on the stream, and an
+  EventEmitter `'error'` with no listener is an `uncaughtException`, which neither the
+  `try { send(…) } catch {}` in `dispose()` nor the `try { await dispose() } catch {}` in
+  `SandboxManager` can intercept. The deterministic route in: the request watchdog SIGKILLs the
+  worker, `SandboxManager` disposes it, and `dispose()` writes a `shutdown` frame to the corpse →
+  `write EPIPE` → process exit, losing session history and REPL state over a worker that was
+  meant to be disposable. Now every stdio pipe has an `'error'` listener that records to the
+  bounded stderr tail; `send()` drops frames for a dead worker instead of writing (and never
+  throws — `reply()` calls it from a catch block); `request()` rejects up front rather than
+  waiting for the watchdog; and `dispose()` only handshakes a live worker.
+- **Worker deaths now say what happened.** The `exit` handler reports `signal SIGKILL` vs
+  `code 1` alongside the stderr tail, so the surviving `REPL error: …` distinguishes a watchdog
+  kill, an abort, an OOM kill, and a Python-level crash.
+- `dispose()` waits for the worker's actual `exit` event (bounded) instead of sleeping a fixed
+  50 ms on every teardown.
+
+- **Child RLM context inheritance ([#4]).** A recursive `rlm_query` child received the prompt
+  string as its *entire* `context`, so it had no repository files and no libraries — ever.
+  `load_library()` made it visible: the parent would reference `lib/<id>/…` paths, the child
+  would try to resolve them as real directories, fail, and answer from general knowledge with no
+  error surfaced. Children now inherit the parent's live context (repo pack + every loaded
+  library) under the same paths, with `search` / `grep_context` / `outline` / `map_files`
+  working. The prompt becomes the child's question, as at depth 0. This costs **zero extra LLM
+  tokens** — only a size line reaches the model; the content lives in the sandbox.
+- **`contextLength` under-reported file bundles by ~200×.** It summed `String(entry).length`,
+  i.e. `"[object Object]"` (15 chars) per file, so a 3,000-char two-file context reported 30.
+  That number is what the model is told to size its batches against, and it is replayed into the
+  rebuilt system prompt on `/rlm-resume`.
+- **`load_library` could report `already_loaded` for a library that was never appended.** The
+  host committed the sidecar index and loaded-prefix on *pack* success, while the worker could
+  still refuse (non-list context, or a source that packs to zero files). Both refusals are now
+  pre-flighted host-side with the worker's exact wording, before anything is committed.
+- **Libraries were lost on sandbox death-recreate (native mode).** `SandboxManager.contextPayload`
+  was never updated after a `load_library`, so a recreate silently replayed a repo-only context.
+
+### Added
+
+- **`rlm_query(prompt, paths=['src/auth/', 'lib/x-9f3a/'])`** — narrow a child's inherited context
+  to path prefixes (prefix match, not globs). A prefix that matches nothing hands over the full
+  context and says so in the child's prompt, rather than blinding it.
+- **`maxConcurrentChildren`** (default 3) — child engines are now bounded separately from leaf
+  sub-calls (`maxConcurrentSubcalls`, default 6). Each child is a Python subprocess holding its
+  own copy of the inherited context, so the previous shared limit allowed up to 18 concurrent
+  repository-sized workers.
+- Context files are serialized once per payload version and shared by refcount across every
+  child that inherits it, in bounded chunks so a large repository never blocks the event loop.
+
+### Changed
+
+- **Cost profile of `rlm_query`.** A child that used to see a 2 KB prompt now sees the whole
+  repository and has `maxIterations` turns to spend on it, so a fan-out of N children is N real
+  repository analyses. Budget and timeout still descend as *remaining* amounts, so the tree
+  cannot exceed the root cap.
+
+[#4]: https://github.com/openzebra/rlm.pi/issues/4
+
 ## [0.2.1] - 2026-08-08
 
 ### Fixed

--- a/pi-plugin/rlm/README.md
+++ b/pi-plugin/rlm/README.md
@@ -58,7 +58,10 @@ sub-LLM calls, hence the name.
 
 - A **root orchestrator** model drives a **persistent Python REPL** turn-by-turn.
 - Long-context work is **delegated** to cheap worker models via `llm_query` / `llm_query_batched`.
-- Hard sub-problems **recurse** into child RLMs via `rlm_query` (depth-capped).
+- Hard sub-problems **recurse** into child RLMs via `rlm_query` (depth-capped). A child inherits
+  its parent's `context` — the repository plus every library loaded with `load_library()` — so it
+  runs the same retrieval primitives over the same paths. Inheritance costs no extra tokens: the
+  content lives in the sandbox, and only a size line reaches the model.
 - Everything runs **in-process** — the only external process is one local `python3` worker.
 
 > This is a Pi-plugin reimplementation of the RLM method (see the [RLM paper](https://arxiv.org/abs/2512.24601)).
@@ -113,8 +116,8 @@ These functions are injected into the model's Python namespace inside the REPL:
 | `llm_query` | `(prompt, model=None) -> str` | One-shot sub-LLM call (worker model) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | Concurrent sub-LLM calls (pool-bounded) |
 | `llm_query_chunked` | `(text, prompt, model=None) -> list[str]` | Split large text into cap-sized chunks and fan out via sub-LLMs |
-| `rlm_query` | `(prompt, model=None) -> str` | Recursive child RLM with its own sandbox (depth-capped) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | Concurrent recursive child RLMs |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | Recursive child RLM with its own sandbox (depth-capped). Inherits your `context`; `paths` narrows it by prefix |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | Concurrent recursive child RLMs, sharing one `paths` slice |
 | `todo` | `(action, **kwargs) -> str` | Task list: `create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | Ask the user structured questions (depth 0 only) |
 | `load_library` | `(source) -> dict \| str` | Append an external dir, file, or git URL into `context` under `lib/<id>/` |

--- a/pi-plugin/rlm/README.ru.md
+++ b/pi-plugin/rlm/README.ru.md
@@ -34,6 +34,9 @@
 - **Модель-оркестратор** управляет постоянным Python REPL пошагово.
 - Работа с длинным контекстом **делегируется** дешевым worker-моделям через `llm_query` / `llm_query_batched`.
 - Сложные подзадачи **рекурсивно** передаются в дочерние RLM через `rlm_query` (с ограничением глубины).
+  Дочерний RLM наследует `context` родителя — репозиторий и все библиотеки, загруженные через
+  `load_library()`, — и работает с теми же путями. Наследование не стоит дополнительных токенов:
+  содержимое живёт в песочнице, модель видит только строку с размером.
 - Все работает **in-process** — единственным внешним процессом является локальный worker `python3`.
 
 > This is a Pi-plugin reimplementation of the RLM method (see the [RLM paper](https://arxiv.org/abs/2512.24601)).
@@ -107,8 +110,8 @@ rm -rf ~/.pi/agent/extensions/rlm
 | `llm_query` | `(prompt, model=None) -> str` | Одноразовый вызов sub-LLM (worker-модель) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | Параллельные вызовы sub-LLM (с ограничением пула) |
 | `llm_query_chunked` | `(text, prompt, model=None) -> list[str]` | Дробит большой текст на части по лимиту и обрабатывает через sub-LLM |
-| `rlm_query` | `(prompt, model=None) -> str` | Рекурсивный дочерний RLM со своей песочницей (с ограничением глубины) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | Параллельные рекурсивные дочерние RLM |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | Рекурсивный дочерний RLM со своей песочницей (с ограничением глубины). Наследует ваш `context`; `paths` сужает его по префиксу |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | Параллельные рекурсивные дочерние RLM с общим срезом `paths` |
 | `todo` | `(action, **kwargs) -> str` | Список задач: `create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | Задать пользователю структурированные вопросы (только на глубине 0) |
 | `SHOW_VARS` | `() -> str` | Список текущих переменных и их типов |

--- a/pi-plugin/rlm/README.zh-CN.md
+++ b/pi-plugin/rlm/README.zh-CN.md
@@ -33,7 +33,9 @@
 
 - **根编排器**模型逐轮驱动一个**持久化的 Python REPL**。
 - 长上下文工作通过 `llm_query` / `llm_query_batched` **委派**给廉价的工作模型。
-- 困难的子问题通过 `rlm_query` **递归**到子 RLM 中（设有深度限制）。
+- 困难的子问题通过 `rlm_query` **递归**到子 RLM 中（设有深度限制）。子 RLM 继承父级的 `context`
+  ——仓库以及通过 `load_library()` 加载的所有库——因此可以在相同的路径上使用相同的检索原语。
+  继承不消耗额外的 token：内容存放在沙箱中，模型只看到一行大小信息。
 - 所有内容均**在进程内**运行 —— 唯一的外部进程是一个本地的 `python3` worker。
 
 > 这是 RLM 方法的 Pi 插件重新实现（参见 [RLM 论文](https://arxiv.org/abs/2512.24601)）。
@@ -114,8 +116,8 @@ rm -rf ~/.pi/agent/extensions/rlm
 | `llm_query` | `(prompt, model=None) -> str` | 单次子 LLM 调用 (worker 模型) |
 | `llm_query_batched` | `(prompts, model=None) -> list[str]` | 并发子 LLM 调用 (池上限) |
 | `llm_query_chunked` | `(text, prompt, model=None) -> list[str]` | 将大文本拆分为不超过上限的块并通过子 LLM 处理 |
-| `rlm_query` | `(prompt, model=None) -> str` | 具有自有沙箱的递归子 RLM (设有深度限制) |
-| `rlm_query_batched` | `(prompts, model=None) -> list[str]` | 并发递归子 RLM |
+| `rlm_query` | `(prompt, model=None, paths=None) -> str` | 具有自有沙箱的递归子 RLM (设有深度限制)。继承父级的 `context`；`paths` 按前缀缩小范围 |
+| `rlm_query_batched` | `(prompts, model=None, paths=None) -> list[str]` | 并发递归子 RLM，共享同一个 `paths` 切片 |
 | `todo` | `(action, **kwargs) -> str` | 任务列表：`create`/`update`/`list`/`get`/`delete`/`clear` |
 | `ask_user_question` | `(questions) -> list[dict]` | 向用户提出结构化问题 (仅限深度 0) |
 | `SHOW_VARS` | `() -> str` | 列出当前定义的变量及其类型 |

--- a/pi-plugin/rlm/src/bridge/library.ts
+++ b/pi-plugin/rlm/src/bridge/library.ts
@@ -38,26 +38,67 @@ export interface LibraryBridgeOpts {
    * Seeded so re-load after resume is still a no-op without re-packing.
    */
   readonly loadedPrefixes?: readonly string[];
-  /** Post-load hook — the engine writes the resume sidecar here; native mode omits it. */
+  /**
+   * The live context this sandbox holds. Read to refuse pre-flight exactly what the worker's
+   * `_append_library` would reject, before any index or prefix is committed.
+   */
+  readonly getContext?: () => unknown;
+  /**
+   * Post-load hook. The engine writes the resume sidecar here and grows its live context;
+   * native mode grows SandboxManager.contextPayload.
+   */
   readonly onLoaded?: (index: number, payload: unknown) => void | Promise<void>;
 }
 
 export interface LibraryHandlerBundle {
   readonly handlers: Pick<SubLlmHandlers, "loadLibrary">;
-  /** Reset the sidecar index counter (call when the sandbox is discarded and will re-spawn). */
-  readonly reset: () => void;
+  /**
+   * Reset the sidecar index counter and the loaded-prefix cache (call when the sandbox is
+   * discarded and will re-spawn).
+   *
+   * `keep` re-seeds the cache from the payload that will be replayed into the fresh worker.
+   * `loaded` is a CACHE of `libraryPrefixesIn(context)`, never independent state, so it may only
+   * be cleared by re-deriving it — clearing it outright would make the host re-clone and re-pack
+   * a library the recreated worker already holds.
+   */
+  readonly reset: (keep?: readonly string[]) => void;
   /** Prefixes loaded in this sandbox lifetime (for tests). */
   readonly loadedPrefixes: () => ReadonlySet<string>;
 }
+
+/**
+ * JS runtime kind → the Python type name worker.py reports, so both sides emit exactly one
+ * message for the same refusal. Covers every shape a context payload can take after JSON
+ * transport; anything else is a plain object, which `json.load` materializes as a dict.
+ */
+const PY_TYPE_NAME: Readonly<Record<string, string>> = Object.freeze({
+  string: "str", boolean: "bool", number: "int", bigint: "int", undefined: "None",
+});
+
+function pythonKindOf(value: unknown): string {
+  if (value === null) return "None"; // matches worker.py's `if ctx is not None else "None"`
+  return PY_TYPE_NAME[typeof value] ?? "dict";
+}
+
+/**
+ * Refusal messages shared with worker.py `_append_library`. The worker is the backstop; the host
+ * pre-flights the same two conditions so it never commits an index/prefix for an append that
+ * will be rejected. Keep the wording identical — a comment in worker.py points back here.
+ */
+const LIST_CONTEXT_REQUIRED = (kind: string): string =>
+  `load_library requires list context (file bundle); got ${kind}`;
+const NO_FILES_PRODUCED = "load_library produced no files";
 
 export function buildLibraryHandler(opts: LibraryBridgeOpts): LibraryHandlerBundle {
   let nextIndex = opts.startIndex;
   /** Prefixes already loaded in this sandbox — mirrors the worker's context state. */
   const loaded = new Set<string>(opts.loadedPrefixes ?? []);
   return {
-    reset: () => {
-      nextIndex = opts.startIndex;
+    reset: (keep) => {
+      const seed = keep ?? opts.loadedPrefixes ?? [];
       loaded.clear();
+      for (const prefix of seed) loaded.add(prefix);
+      nextIndex = opts.startIndex + seed.length;
     },
     loadedPrefixes: () => loaded,
     handlers: {
@@ -74,6 +115,13 @@ export function buildLibraryHandler(opts: LibraryBridgeOpts): LibraryHandlerBund
           depth,
         });
         try {
+          // Pre-flight the worker's own refusal: a non-list context cannot be appended to, and
+          // committing an index/prefix for it would make the NEXT load lie with already_loaded.
+          const current = opts.getContext?.();
+          if (current !== undefined && !Array.isArray(current)) {
+            throw new Error(LIST_CONTEXT_REQUIRED(pythonKindOf(current)));
+          }
+
           // Cheap pre-check BEFORE cloning/packing: same namespace ⇒ nothing to do.
           const { sourceId: preId, pathPrefix: prefix } = libraryNamespace(source, cwd);
           if (loaded.has(prefix)) {
@@ -99,6 +147,8 @@ export function buildLibraryHandler(opts: LibraryBridgeOpts): LibraryHandlerBund
           const resolved = await resolveLibrarySource(source, cwd, opts.signal);
           if (!resolved.ok) throw new Error(resolved.error);
           const { payload, files, chars, sourceId, pathPrefix } = resolved.value;
+          // The worker's other refusal, pre-flighted for the same reason.
+          if (payload.length === 0) throw new Error(NO_FILES_PRODUCED);
 
           // Race: another concurrent load of the same prefix finished while we packed.
           if (loaded.has(pathPrefix)) {

--- a/pi-plugin/rlm/src/bridge/subcall-handlers.ts
+++ b/pi-plugin/rlm/src/bridge/subcall-handlers.ts
@@ -20,6 +20,7 @@ import { displayModelRef, modelRef, resolveModelId } from "../config/settings.ts
 import { type ChatMsg, modelComplete } from "./model.ts";
 import { previewText } from "../text/preview.ts";
 import { checkResourceLimits } from "../core/resource-limits.ts";
+import { filterContextByPaths } from "../context/library-context.ts";
 import type { RlmInput, RlmResult, Sampling } from "../core/types.ts";
 import type { SubcallGates } from "../util/concurrency.ts";
 import type { SubcallOpts, SubLlmHandlers } from "../sandbox/sandbox.ts";
@@ -107,6 +108,15 @@ export interface SubcallHandlerDeps {
    * one emitter is what lets the session registry drain the subtree intact.
    */
   readonly runChild?: (input: RlmInput, inv: Invocation) => Promise<RlmResult>;
+  /**
+   * The parent's live context, read at spawn time and never captured: a library loaded on turn 3
+   * must reach a child spawned on turn 4. `undefined`/`null` ⇒ no inheritance, and the child falls
+   * back to prompt-as-context.
+   *
+   * This is the ONLY inheritance seam. Adding a second construction path for a child's world
+   * would re-open issue #4 on whichever path forgets to grow.
+   */
+  readonly getChildContext?: () => unknown;
   readonly getModel?: () => Model<Api>;
   /**
    * What rlm_query degrades to at the depth cap. A child RLM there would just be an LM, so
@@ -140,6 +150,14 @@ const UNWIRED = formatError("RLM bridge not wired for this invocation");
 function emptyResult(answer: string): RlmResult {
   return { answer, iterations: 0, costUsd: 0, inputTokens: 0, outputTokens: 0, durationMs: 0 };
 }
+
+/** What a child RLM will see, plus any `paths=` prefix that selected nothing. */
+interface ChildContext {
+  readonly context: unknown;
+  readonly unmatched: readonly string[];
+}
+
+const NO_UNMATCHED: readonly string[] = Object.freeze([]);
 
 export function createSubcallHandlers(deps: SubcallHandlerDeps): SubcallHandlers {
   /** DRY #3 — the one display-model resolution. */
@@ -237,10 +255,37 @@ export function createSubcallHandlers(deps: SubcallHandlerDeps): SubcallHandlers
   }
 
   /**
+   * Resolve the child's world: the parent's live context, optionally narrowed by path prefixes.
+   *
+   * Falls back to prompt-as-context when nothing is wired, and to the FULL context when `paths`
+   * matched nothing — a silently blind child is exactly the bug this fixes, so a bad prefix
+   * degrades loudly (see the note childRun folds into rootPrompt) rather than quietly.
+   */
+  function childContextFor(prompt: string, paths: readonly string[] | undefined): ChildContext {
+    const inherited = deps.getChildContext?.();
+    if (inherited === undefined || inherited === null) {
+      return Object.freeze({ context: prompt, unmatched: NO_UNMATCHED });
+    }
+    if (paths === undefined || paths.length === 0) {
+      return Object.freeze({ context: inherited, unmatched: NO_UNMATCHED });
+    }
+    const filtered = filterContextByPaths(inherited, paths);
+    return Object.freeze({
+      context: filtered.files.length > 0 ? filtered.files : inherited,
+      unmatched: filtered.unmatched,
+    });
+  }
+
+  /**
    * One child RLM run: depth cap → resource guard → spawn engine → debit parent.
    * Emits its own subcall node, so callers must not wrap it in another.
    */
-  async function childRun(inv: Invocation, prompt: string, model: string | null): Promise<RlmResult> {
+  async function childRun(
+    inv: Invocation,
+    prompt: string,
+    model: string | null,
+    paths: readonly string[] | undefined,
+  ): Promise<RlmResult> {
     const childDepth = inv.depth + 1;
     const run = deps.runChild;
     const maxDepth = deps.getConfig().maxDepth;
@@ -268,10 +313,16 @@ export function createSubcallHandlers(deps: SubcallHandlerDeps): SubcallHandlers
       kind: "rlm", parentId: inv.parentId, label: "rlm_query",
       model: modelLabel, detail: prompt.slice(0, 60), depth: childDepth,
     });
+    // The child's context is the parent's world, not the prompt text. The prompt becomes the
+    // child's rootPrompt, exactly as a depth-0 run takes the user's question.
+    const child = childContextFor(prompt, paths);
+    const rootPrompt = child.unmatched.length === 0
+      ? prompt
+      : `${prompt}\n\n[rlm] paths=${child.unmatched.join(", ")} matched no files; you received the full context.`;
     try {
       const res = await deps.gates.rlm.at(childDepth).run(() => run({
-        rootPrompt: "",
-        context: prompt,
+        rootPrompt,
+        context: child.context,
         depth: childDepth,
         parentNodeId: subId,
         modelOverride: model ?? undefined,
@@ -320,7 +371,7 @@ export function createSubcallHandlers(deps: SubcallHandlerDeps): SubcallHandlers
     async rlmQuery(prompt, model, depth, opts) {
       const inv = deps.resolve(opts, depth);
       if (inv === null) return UNWIRED;
-      return detachable(opts, async () => (await childRun(inv, prompt, model)).answer);
+      return detachable(opts, async () => (await childRun(inv, prompt, model, opts.paths)).answer);
     },
 
     async rlmQueryBatched(prompts, model, depth, opts) {
@@ -328,7 +379,7 @@ export function createSubcallHandlers(deps: SubcallHandlerDeps): SubcallHandlers
       if (inv === null) return prompts.map(() => UNWIRED);
       // Bounded by the per-depth rlm gate inside childRun, not by an outer pool.
       return detachable(opts, async () => {
-        const results = await Promise.all(prompts.map((p) => childRun(inv, p, model)));
+        const results = await Promise.all(prompts.map((p) => childRun(inv, p, model, opts.paths)));
         return results.map((r) => r.answer);
       });
     },

--- a/pi-plugin/rlm/src/config/defaults.ts
+++ b/pi-plugin/rlm/src/config/defaults.ts
@@ -17,9 +17,12 @@ export const DEFAULT_CONFIG: Readonly<RlmConfig> = Object.freeze({
   execTimeoutS: 120,
   requestTimeoutMs: 10 * 60_000,
   // Session-wide, not per-batch: spawn() puts many requests on the wire at once, so this is
-  // the only thing bounding fan-out. Worst case is maxDepth × this many child engines (each
-  // owning a Python subprocess) plus this many leaf completions — keep it modest.
+  // the only thing bounding leaf fan-out. Keep it modest.
   maxConcurrentSubcalls: 6,
+  // Children are bounded separately and lower: each is a Python subprocess holding its own copy
+  // of the context it inherited, where a leaf is one HTTP request. Worst case is
+  // (maxDepth - 1) × this many concurrent child engines.
+  maxConcurrentChildren: 3,
   maxPromptChars: 400_000,
   maxErrors: 5,
   orchestrator: true,

--- a/pi-plugin/rlm/src/config/settings.ts
+++ b/pi-plugin/rlm/src/config/settings.ts
@@ -74,6 +74,8 @@ function validateConfig(raw: unknown): Partial<RlmConfig> {
   if (requestTimeoutMs !== undefined) out.requestTimeoutMs = requestTimeoutMs;
   const maxConcurrentSubcalls = validateNumber(r.maxConcurrentSubcalls, 1);
   if (maxConcurrentSubcalls !== undefined) out.maxConcurrentSubcalls = maxConcurrentSubcalls;
+  const maxConcurrentChildren = validateNumber(r.maxConcurrentChildren, 1);
+  if (maxConcurrentChildren !== undefined) out.maxConcurrentChildren = maxConcurrentChildren;
   const maxPromptChars = validateNumber(r.maxPromptChars, 1000);
   if (maxPromptChars !== undefined) out.maxPromptChars = maxPromptChars;
   const maxBudgetUsd = validateNumber(r.maxBudgetUsd, 0.01);

--- a/pi-plugin/rlm/src/context/library-context.ts
+++ b/pi-plugin/rlm/src/context/library-context.ts
@@ -150,18 +150,95 @@ export function namespaceLibraryFiles(
   return namespaceLibraryFilesWithChars(payload, sourceId).files;
 }
 
+/** The one `lib/<id>/` matcher. Never re-declare this regex; use the helpers below. */
+const LIB_PREFIX_RE = /^(lib\/[^/]+\/)/;
+
+/** Narrow an unknown context entry to a ContextFile. Type guard, never a cast. */
+export function isContextFile(entry: unknown): entry is ContextFile {
+  if (entry === null || typeof entry !== "object") return false;
+  return "path" in entry && typeof entry.path === "string"
+    && "content" in entry && typeof entry.content === "string";
+}
+
+/** `path` of a context entry, or undefined when the entry is not file-shaped. */
+export function contextEntryPath(entry: unknown): string | undefined {
+  return isContextFile(entry) ? entry.path : undefined;
+}
+
+/** The `lib/<id>/` prefix owning this path, or undefined. Skips the legacy catch-all. */
+function libPrefixOf(path: string): string | undefined {
+  const prefix = LIB_PREFIX_RE.exec(path)?.[1];
+  // `lib/unknown/` is the legacy catch-all: never treat it as an identity.
+  return prefix === undefined || prefix === LEGACY_UNKNOWN_PREFIX ? undefined : prefix;
+}
+
 /** First `lib/<id>/` prefix found in the payload, or undefined. Skips `lib/unknown/`. */
 export function payloadPrefix(payload: readonly unknown[]): string | undefined {
   for (let i = 0; i < payload.length; i++) {
-    const item = payload[i];
-    if (item === null || typeof item !== "object") continue;
-    const path = (item as { path?: unknown }).path;
-    if (typeof path !== "string") continue;
-    const m = /^(lib\/[^/]+\/)/.exec(path);
-    // `lib/unknown/` is the legacy catch-all: never treat it as an identity.
-    if (m?.[1] !== undefined && m[1] !== LEGACY_UNKNOWN_PREFIX) return m[1];
+    const path = contextEntryPath(payload[i]);
+    if (path === undefined) continue;
+    const prefix = libPrefixOf(path);
+    if (prefix !== undefined) return prefix;
   }
   return undefined;
+}
+
+/**
+ * Every distinct `lib/<id>/` prefix present in a context payload.
+ *
+ * The loaded-prefix set in bridge/library.ts is a CACHE of this — derived state, never
+ * independent state, so it may only be cleared by re-deriving it from the live payload.
+ */
+export function libraryPrefixesIn(context: unknown): readonly string[] {
+  if (!Array.isArray(context)) return Object.freeze([]);
+  const seen = new Set<string>();
+  for (let i = 0; i < context.length; i++) {
+    const path = contextEntryPath(context[i]);
+    if (path === undefined) continue;
+    const prefix = libPrefixOf(path);
+    if (prefix !== undefined) seen.add(prefix);
+  }
+  return Object.freeze(Array.from(seen));
+}
+
+export interface FilteredContext {
+  readonly files: readonly ContextFile[];
+  /** Prefixes that selected zero files — the caller decides whether that is fatal. */
+  readonly unmatched: readonly string[];
+}
+
+/**
+ * Narrow a context payload to entries under any of `prefixes` (plain prefix match, no globs).
+ *
+ * Backs `rlm_query(prompt, paths=[…])`. Prefix-only is deliberate: the sandbox's own filters use
+ * Python `fnmatch`, which has no host-side equivalent here, and a subtree prefix is what callers
+ * actually want — the child can still `search()` inside the slice.
+ */
+export function filterContextByPaths(context: unknown, prefixes: readonly string[]): FilteredContext {
+  if (!Array.isArray(context) || prefixes.length === 0) {
+    return Object.freeze({ files: Object.freeze([]), unmatched: Object.freeze(Array.from(prefixes)) });
+  }
+  const hit = new Array<boolean>(prefixes.length).fill(false);
+  const out = new Array<ContextFile>(context.length); // pre-allocated, trimmed once below
+  let n = 0;
+  for (let i = 0; i < context.length; i++) {
+    const entry: unknown = context[i];
+    if (!isContextFile(entry)) continue;
+    for (let p = 0; p < prefixes.length; p++) {
+      if (!entry.path.startsWith(prefixes[p])) continue;
+      hit[p] = true;
+      out[n++] = entry;
+      break;
+    }
+  }
+  out.length = n;
+  const unmatched = new Array<string>(prefixes.length); // pre-allocated, no .push()
+  let u = 0;
+  for (let p = 0; p < prefixes.length; p++) {
+    if (!hit[p]) unmatched[u++] = prefixes[p];
+  }
+  unmatched.length = u;
+  return Object.freeze({ files: Object.freeze(out), unmatched: Object.freeze(unmatched) });
 }
 
 /**
@@ -175,12 +252,8 @@ export function mergeLibraryIntoContext(base: unknown, libraryPayload: unknown):
     const prefix = payloadPrefix(libraryPayload);
     if (prefix !== undefined) {
       for (let i = 0; i < base.length; i++) {
-        const item = base[i];
-        if (item !== null && typeof item === "object"
-          && typeof (item as { path?: unknown }).path === "string"
-          && (item as { path: string }).path.startsWith(prefix)) {
-          return base; // already present
-        }
+        const path = contextEntryPath(base[i]);
+        if (path !== undefined && path.startsWith(prefix)) return base; // already present
       }
     }
     const merged = new Array<unknown>(base.length + libraryPayload.length);

--- a/pi-plugin/rlm/src/core/engine.ts
+++ b/pi-plugin/rlm/src/core/engine.ts
@@ -16,7 +16,7 @@ import type { Api, Model, Usage } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { buildInteractiveHandlers } from "../bridge/interactive.ts";
 import { buildLibraryHandler } from "../bridge/library.ts";
-import { mergeLibraryIntoContext } from "../context/library-context.ts";
+import { libraryPrefixesIn, mergeLibraryIntoContext } from "../context/library-context.ts";
 import {
   createSubcallHandlers,
   type Invocation,
@@ -28,6 +28,7 @@ import { buildTurnPrompt, FINALIZE_PROMPT } from "../prompts/user.ts";
 import { phaseGuidance } from "../prompts/phases.ts";
 import type { RlmEmitter } from "../tool/rlm-events.ts";
 import { PythonSandbox } from "../sandbox/sandbox.ts";
+import { pinContext, type PinnedContext } from "../sandbox/context-file.ts";
 import {
   phaseGatePrompt,
   type Phase,
@@ -209,13 +210,18 @@ export function createEngine(deps: EngineDeps): RunRlm {
     let detachedIdle: (() => void) | undefined;
     const subcalls = createSubcallHandlers({
       resolve: () => invocation,
-      gates: deps.gates ?? createSubcallGates(deps.config.maxConcurrentSubcalls),
+      gates: deps.gates
+        ?? createSubcallGates(deps.config.maxConcurrentSubcalls, deps.config.maxConcurrentChildren),
       registry: deps.registry,
       getWorkerModel: () => deps.workerModel,
       getModel: () => model,
       getConfig: () => deps.config,
       signal: deps.signal,
       runChild: run,
+      // Read lazily: a library loaded on turn 3 must reach a child spawned on turn 4. Safe
+      // despite being wired before liveContext is assigned — children can only spawn from an
+      // interrupt during runTurn, which is strictly after loadContext below.
+      getChildContext: () => liveContext,
       trackDetached: async (task) => {
         detachedInFlight += 1;
         try {
@@ -236,6 +242,25 @@ export function createEngine(deps: EngineDeps): RunRlm {
       detachedIdle = undefined;
     };
     let sandbox: PythonSandbox | undefined;
+    /**
+     * This run's live context: the repo pack plus every library loaded so far. Children inherit
+     * it, so it must grow when load_library appends (see the library handler's onLoaded below).
+     *
+     * Run-scoped on purpose — recursion means N of these are live at once, and a module-level
+     * "current context" would hand a depth-3 child its cousin's world.
+     */
+    let liveContext: unknown = null;
+    /**
+     * This run's hold on the serialized context file. Kept for the whole run so every child that
+     * inherits the same payload reuses one file instead of re-serializing the repository.
+     */
+    let contextPin: PinnedContext | undefined;
+    /** Re-pin after the payload changes identity (mergeLibraryIntoContext returns a new array). */
+    const repinLiveContext = async (): Promise<void> => {
+      const previous = contextPin;
+      contextPin = await pinContext(liveContext);
+      await previous?.release();
+    };
     let best = "";
     let lastAnswer = "";
     let compactions = 0;
@@ -310,6 +335,7 @@ export function createEngine(deps: EngineDeps): RunRlm {
         pipeline: deps.config.pipeline && input.depth === 0,
         maxPromptChars: deps.config.maxPromptChars,
         libraryLoader: deps.config.libraryLoader,
+        child: input.depth > 0,
       });
 
       pipeline = new PipelineController({
@@ -348,26 +374,23 @@ export function createEngine(deps: EngineDeps): RunRlm {
         ? await readLibrarySidecars(deps.runState.cwd, deps.runState.dir, runId)
         : [];
       // Seed host-side idempotency from restored sidecars so re-load is a no-op.
-      const restoredPrefixes: string[] = [];
-      for (const slot of restoredSlots) {
-        if (!Array.isArray(slot.payload) || slot.payload.length === 0) continue;
-        const first = slot.payload[0];
-        if (first === null || typeof first !== "object") continue;
-        const path = typeof (first as { path?: unknown }).path === "string"
-          ? (first as { path: string }).path
-          : "";
-        const m = path.match(/^(lib\/[^/]+\/)/);
-        if (m?.[1] !== undefined) restoredPrefixes.push(m[1]);
-      }
+      const restoredPrefixes: readonly string[] =
+        restoredSlots.flatMap((slot) => libraryPrefixesIn(slot.payload));
       const libraryHandlers = deps.config.libraryLoader
         ? buildLibraryHandler({
             cwd: runCwd,
             emitter,
             parentId: selfReportId,
             signal: deps.signal,
+            getContext: () => liveContext,
             startIndex: 1 + restoredSlots.reduce((m, s) => Math.max(m, s.index), 0),
             loadedPrefixes: restoredPrefixes,
             onLoaded: async (index, payload) => {
+              // FIRST and unconditional: the accumulator is what children inherit, and it must
+              // not depend on whether run-state persistence happens to be enabled. This is also
+              // what makes inheritance transitive — grandchildren see the library too.
+              liveContext = mergeLibraryIntoContext(liveContext, payload);
+              await repinLiveContext();
               if (!persistOn || !runId || !deps.runState) return;
               await writeContextSidecar(
                 deps.runState.cwd, deps.runState.dir, runId,
@@ -419,14 +442,15 @@ export function createEngine(deps: EngineDeps): RunRlm {
 
       // Context: serialize ContextBundle to sandbox-ready JSON array, pass raw strings through.
       // Resume: merge library sidecars into the single `context` list (no context_N slots).
-      let contextValue: unknown =
+      liveContext =
         typeof input.context === "object" && input.context !== null && "files" in input.context
           ? serializeForSandbox(input.context as ContextBundle)
           : input.context;
       for (const slot of restoredSlots) {
-        contextValue = mergeLibraryIntoContext(contextValue, slot.payload);
+        liveContext = mergeLibraryIntoContext(liveContext, slot.payload);
       }
-      await sandbox.loadContext(contextValue);
+      contextPin = await pinContext(liveContext);
+      await sandbox.loadContextPinned(contextPin);
       if (input.resume?.snapshotTurn !== undefined && deps.runState && runId && sessionNonce) // R-C1: restore only for same-session (sessionNonce present)
         await sandbox.restore(snapshotPath(deps.runState.cwd, deps.runState.dir, runId, input.resume.snapshotTurn), sessionNonce);
       for (let i = startTurn; i < deps.config.maxIterations; i++) {
@@ -607,7 +631,9 @@ export function createEngine(deps: EngineDeps): RunRlm {
         if (nodeStatus !== "error" && lastAnswer) emitter.emitAnswer(previewText(lastAnswer));
         emitter.emitStatus(nodeStatus === "error" ? "error" : "done");
       }
+      // Settle detached work FIRST: a child still running may be about to pin this same payload.
       await settleDetached();
+      await contextPin?.release();
       await sandbox?.dispose();
     }
   };

--- a/pi-plugin/rlm/src/core/types.ts
+++ b/pi-plugin/rlm/src/core/types.ts
@@ -34,6 +34,9 @@ export interface RlmConfig {
   readonly requestTimeoutMs: number;
   /** Concurrency pool for *_batched sub-calls. */
   readonly maxConcurrentSubcalls: number;
+  /** Concurrent recursive child engines admitted per depth. Lower than maxConcurrentSubcalls:
+   *  each child is a Python subprocess holding its own copy of the inherited context. */
+  readonly maxConcurrentChildren: number;
   /** Reject sub-LLM prompts larger than this many chars. */
   readonly maxPromptChars: number;
   /** Max USD spend across the whole tree before the engine stops (undefined = no cap). */

--- a/pi-plugin/rlm/src/index.ts
+++ b/pi-plugin/rlm/src/index.ts
@@ -42,7 +42,7 @@ export default function rlmExtension(pi: ExtensionAPI): void {
   });
   // One admission gate for the whole session: spawn() lets the sandbox put many requests on
   // the wire at once, so nothing smaller than session scope actually bounds fan-out.
-  const gates = createSubcallGates(config.maxConcurrentSubcalls);
+  const gates = createSubcallGates(config.maxConcurrentSubcalls, config.maxConcurrentChildren);
   const background = new BackgroundTasks({
     maxBudgetUsd: config.maxBudgetUsd,
     maxTimeoutMs: config.maxTimeoutMs,

--- a/pi-plugin/rlm/src/prompts/system.ts
+++ b/pi-plugin/rlm/src/prompts/system.ts
@@ -21,6 +21,8 @@ export interface SystemPromptOptions {
   readonly pipeline?: boolean;
   readonly maxPromptChars?: number;
   readonly libraryLoader?: boolean;
+  /** depth > 0 — this run is an rlm_query child and its `context` is the parent's world. */
+  readonly child?: boolean;
 }
 
 export type ContextKind = "files" | "text";
@@ -89,6 +91,35 @@ const SPAWN_GLOSSARY_LINES: readonly string[] = Object.freeze([
   "  hits = [f for f in context if \"TODO\" in f[\"content\"]]   # overlaps with the sub-agents",
   "  reports = rlm_await_all(tasks)",
   "  ```",
+]);
+
+/**
+ * What a parent must know about the child it is about to spawn. Without this the model writes
+ * referential prompts ("read lib/x/src/…") on the assumption the child can go fetch them, which
+ * is what made a missing child context degrade silently instead of failing (issue #4).
+ */
+const RECURSION_CONTEXT_LINES: readonly string[] = Object.freeze([
+  "",
+  "  **What a child sees:** it inherits YOUR `context` — the repository plus every library you",
+  "  loaded (`lib/<id>/…`) — and runs `search` / `grep_context` / `outline` / `map_files` over the",
+  "  same paths. So send instructions, never file bodies: pasting content you already share costs",
+  "  your tokens twice and buys nothing. Your prompt becomes the child's question.",
+  "  Narrow its world with `rlm_query(prompt, paths=['src/auth/', 'lib/x-9f3a/'])` — path PREFIXES,",
+  "  not globs. Omit `paths` to hand over everything.",
+  "  Inheritance is one-way: libraries the child loads, and its whole REPL, die with it — only its",
+  "  final answer string returns.",
+  "  At the depth cap `rlm_query` degrades to a plain sub-LLM call with NO context, which is why",
+  "  this section disappears at the last recursive depth.",
+]);
+
+/**
+ * Sub-RLM orientation. Emitted only at depth > 0, where `context` is the parent's world rather
+ * than a repository the run packed for itself.
+ */
+const CHILD_CONTEXT_LINES: readonly string[] = Object.freeze([
+  "  You are a sub-RLM. This `context` is your parent's world — the repository plus every library",
+  "  it loaded (paths under `lib/<id>/…`). Answer only the question above; your REPL and anything",
+  "  you load die with you, and only your final answer string returns to the parent.",
 ]);
 
 /** Why a file the user mentioned may be missing from `context`. */
@@ -191,6 +222,7 @@ function replGlossary(
   todo: boolean,
   pipeline: boolean,
   libraryLoader: boolean,
+  child: boolean,
 ): string {
   const lines = ["Available in the REPL:"];
   if (kind === "text") {
@@ -206,6 +238,9 @@ function replGlossary(
       "  For large repos, chunk `context` into batches and delegate to sub-LLMs — never dump raw file",
       "  bodies into your own output.",
       CONTEXT_EXCLUSION_NOTE,
+    );
+    if (child) lines.push(...CHILD_CONTEXT_LINES);
+    lines.push(
       "",
       "  Worked example — find the slice, then delegate it:",
       "  ```python",
@@ -279,6 +314,7 @@ function replGlossary(
       "    execution (e.g. a sub-context large enough to need its own chunking, or a multi-step",
       "    reasoning chain). It is slower and more expensive — reserve it for cases `llm_query` cannot",
       "    handle. Avoid excessive recursive sub-calls when a batched one-shot would suffice.",
+      ...RECURSION_CONTEXT_LINES,
     );
   }
   if (pipeline) {
@@ -343,7 +379,7 @@ export function buildRlmSystemPrompt(meta: PromptMeta, opts: SystemPromptOptions
     "",
     replGlossary(
       kind, recursion, opts.askUserQuestion ?? false, opts.todo ?? false,
-      opts.pipeline ?? false, opts.libraryLoader ?? false,
+      opts.pipeline ?? false, opts.libraryLoader ?? false, opts.child ?? false,
     ),
     "",
     "REPL stdout over ~800 characters is truncated to a short excerpt — large results stay in your",
@@ -386,7 +422,7 @@ function nativeReplGlossary(): string {
     "- `llm_query(prompt, model=None) -> str` — one-shot sub-LLM. Use for extraction, summarization, Q&A over a chunk.",
     "- `llm_query_batched(prompts, model=None) -> list[str]` — concurrent sub-LLM calls; output order matches input order.",
     CHUNKED_GLOSSARY_LINE_NATIVE,
-    "- `rlm_query(prompt, model=None) -> str` — recursive RLM with its own REPL for complex sub-tasks needing iterative reasoning. Prefer llm_query — rlm_query is slower and costlier.",
+    "- `rlm_query(prompt, model=None, paths=None) -> str` — recursive RLM with its own REPL for complex sub-tasks needing iterative reasoning. Prefer llm_query — rlm_query is slower and costlier. The child inherits your `context` (repo + loaded libraries) and takes your prompt as its question, so describe the task; never paste file text. `paths=['src/auth/']` narrows its context by prefix.",
     "- `rlm_query_batched(prompts, model=None) -> list[str]` — concurrent recursive RLM calls.",
     "- `spawn(fn, *args) -> Task` / `rlm_await(t)` / `rlm_await_all(ts)` — start `llm_query`, `llm_query_batched`, `llm_query_chunked`, `map_files`, `rlm_query` or `rlm_query_batched` without waiting (NOT `llm_map_reduce`); collect later, order preserved. Tasks outlive the repl() call, so spawn slow work early and await when you need it.",
     "",

--- a/pi-plugin/rlm/src/sandbox/context-file.ts
+++ b/pi-plugin/rlm/src/sandbox/context-file.ts
@@ -1,0 +1,154 @@
+/**
+ * Temp-file transport for sandbox context payloads, with refcounted sharing.
+ *
+ * Two callers, two ownership models, one writer:
+ *  - `writeContextTempFile` — non-owning. `load_library` uses it because the WORKER unlinks
+ *    that file after reading it (see sandbox.ts serviceInterrupt / worker.py `_load_library`).
+ *  - `pinContext` — refcounted. Every child RLM of one node inherits the SAME payload, so an
+ *    18-way fan-out would otherwise cost 18 serializations and 18 files. Pins are keyed by
+ *    payload identity, which is a free version key: `mergeLibraryIntoContext` always returns a
+ *    NEW array, so loading a library mints a new key and old holders keep their own file.
+ *
+ * Serialization is chunked with an await between chunks so the event loop is never blocked for
+ * more than ~SERIALIZE_CHUNK entries. A Worker Thread was considered and rejected: posting the
+ * payload structured-clones the whole array, which costs about what the stringify costs and
+ * doubles peak RSS.
+ */
+
+import { open, unlink, type FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Entries serialized per await. Bounds the longest synchronous span on the event loop. */
+const SERIALIZE_CHUNK = 64;
+
+/** A temp file on disk holding a serialized context payload. */
+export interface ContextTempFile {
+  readonly path: string;
+  /** True when the file holds JSON; false when the payload was a raw string. */
+  readonly json: boolean;
+}
+
+/** A shared, refcounted context file. Every holder must `release()` exactly once. */
+export interface PinnedContext extends ContextTempFile {
+  /** Drop this holder's reference; unlinks once the last holder releases. Idempotent. */
+  release(): Promise<void>;
+}
+
+interface PinEntry extends ContextTempFile {
+  refs: number;
+}
+
+/**
+ * Live pins keyed by payload identity, storing the in-flight PROMISE rather than the settled
+ * entry. Children of one node race here (each drives its own sandbox, so nothing else
+ * serializes them); inserting the promise before the first await makes them join one write
+ * instead of each starting their own and orphaning the loser's file.
+ */
+const pins = new Map<unknown, Promise<PinEntry>>();
+
+function tempPath(isJson: boolean): string {
+  const suffix = isJson ? "json" : "txt";
+  return join(
+    tmpdir(),
+    `rlm-ctx-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${suffix}`,
+  );
+}
+
+/** Write a JSON array incrementally, yielding to the event loop between chunks. */
+async function writeChunkedArray(handle: FileHandle, items: readonly unknown[]): Promise<void> {
+  await handle.write("[");
+  const buf = new Array<string>(SERIALIZE_CHUNK);
+  let n = 0;
+  for (let i = 0; i < items.length; i++) {
+    // Comma prefix beats trimming a trailing one; no `+=` accumulation anywhere.
+    buf[n++] = i === 0 ? JSON.stringify(items[i]) : `,${JSON.stringify(items[i])}`;
+    if (n === SERIALIZE_CHUNK) {
+      await handle.write(buf.join("")); // the await is the yield point
+      n = 0;
+    }
+  }
+  if (n > 0) await handle.write(buf.slice(0, n).join(""));
+  await handle.write("]");
+}
+
+/**
+ * Serialize a payload to a fresh temp file. The caller owns the file and decides when (or
+ * whether) to unlink it.
+ */
+export async function writeContextTempFile(payload: unknown): Promise<ContextTempFile> {
+  const json = typeof payload !== "string";
+  const path = tempPath(json);
+  try {
+    const handle = await open(path, "w");
+    try {
+      if (typeof payload === "string") await handle.write(payload);
+      else if (Array.isArray(payload)) await writeChunkedArray(handle, payload);
+      else await handle.write(JSON.stringify(payload));
+    } finally {
+      await handle.close();
+    }
+  } catch (err) {
+    await unlink(path).catch(() => {});
+    throw err;
+  }
+  return Object.freeze({ path, json });
+}
+
+async function writePinEntry(payload: unknown): Promise<PinEntry> {
+  const file = await writeContextTempFile(payload);
+  return { path: file.path, json: file.json, refs: 1 };
+}
+
+/** One holder's view of a pin. `shared` entries are evicted from the map at refcount zero. */
+function handleFor(key: unknown, entry: PinEntry, shared: boolean): PinnedContext {
+  let released = false;
+  return Object.freeze({
+    path: entry.path,
+    json: entry.json,
+    release: async (): Promise<void> => {
+      if (released) return; // idempotent per handle, so a `finally` cannot double-decrement
+      released = true;
+      entry.refs -= 1;
+      if (entry.refs > 0) return;
+      if (shared) pins.delete(key);
+      await unlink(entry.path).catch(() => {});
+    },
+  });
+}
+
+/**
+ * Acquire a shared context file for `payload`. Holders must `release()` exactly once; the file
+ * is unlinked when the last one does.
+ */
+export async function pinContext(payload: unknown): Promise<PinnedContext> {
+  // Only arrays are shared. Their identity is a meaningful version key; a string's is not
+  // (two equal strings may or may not be the same reference), and the string payloads here are
+  // one-off child prompts with nothing to share anyway.
+  if (!Array.isArray(payload)) {
+    return handleFor(payload, await writePinEntry(payload), false);
+  }
+
+  const existing = pins.get(payload);
+  if (existing !== undefined) {
+    const entry = await existing;
+    entry.refs += 1;
+    return handleFor(payload, entry, true);
+  }
+
+  // Insert synchronously, BEFORE any await, so a concurrent caller sees this write in flight.
+  const pending = writePinEntry(payload);
+  pins.set(payload, pending);
+  try {
+    return handleFor(payload, await pending, true);
+  } catch (err) {
+    // Evict the rejected promise so a later caller retries instead of awaiting a poisoned pin.
+    pins.delete(payload);
+    throw err;
+  }
+}
+
+/** Live pin count. Exported for tests asserting the sharing and the unlink-once behaviour. */
+export function pinnedCount(): number {
+  return pins.size;
+}

--- a/pi-plugin/rlm/src/sandbox/protocol.ts
+++ b/pi-plugin/rlm/src/sandbox/protocol.ts
@@ -100,12 +100,19 @@ interface PromptInterrupt extends InterruptBase {
   readonly type: "llm_query" | "rlm_query";
   readonly prompt?: string;
   readonly model?: string | null;
+  /**
+   * `rlm_query` only — path prefixes narrowing the child's inherited context. Never sent for
+   * `llm_query`, whose frame stays byte-identical to before.
+   */
+  readonly paths?: readonly string[];
 }
 
 interface BatchedPromptInterrupt extends InterruptBase {
   readonly type: "llm_query_batched" | "rlm_query_batched";
   readonly prompts?: readonly string[];
   readonly model?: string | null;
+  /** `rlm_query_batched` only — one prefix set shared by every prompt in the batch. */
+  readonly paths?: readonly string[];
 }
 
 interface AdvancePhaseInterrupt extends InterruptBase {

--- a/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
+++ b/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
@@ -6,6 +6,7 @@
 
 import { PythonSandbox, type SubLlmHandlers } from "./sandbox.ts";
 import type { ReplResult } from "./protocol.ts";
+import { mergeLibraryIntoContext } from "../context/library-context.ts";
 
 /** Static configuration for sandbox creation — set once, reused across getOrCreate calls. */
 export interface SandboxManagerConfig {
@@ -33,6 +34,18 @@ export class SandboxManager {
   private contextLoaded = false;
 
   constructor(private readonly config: SandboxManagerConfig) {}
+
+  /**
+   * Append a library payload to the context this manager replays on death-recreate.
+   *
+   * The live worker has ALREADY appended it in-process (worker.py `_append_library`), so this
+   * deliberately does not reload — it only keeps the host's replay copy truthful. Without it a
+   * recreate silently rolls the sandbox back to a repo-only context, and any child inheriting
+   * this payload would never see the library. Dedups by `lib/<id>/` prefix.
+   */
+  appendLibrary(payload: unknown): void {
+    this.contextPayload = mergeLibraryIntoContext(this.contextPayload, payload);
+  }
 
   /**
    * Lazy get-or-create the sandbox. On first call, spawns PythonSandbox with the

--- a/pi-plugin/rlm/src/sandbox/sandbox.ts
+++ b/pi-plugin/rlm/src/sandbox/sandbox.ts
@@ -8,8 +8,7 @@
  */
 
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { writeFile, unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { once } from "node:events";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -24,6 +23,7 @@ import {
   type WorkerRequest,
   type WorkerResponse,
 } from "./protocol.ts";
+import { pinContext, writeContextTempFile, type PinnedContext } from "./context-file.ts";
 import { errorMessage, formatError } from "../util/errors.ts";
 import { trace, traceEnabled } from "../util/trace.ts";
 
@@ -48,6 +48,11 @@ export interface LibraryLoadResult {
 export interface SubcallOpts {
   /** Started via `spawn()` — route to session-scoped state, not the current invocation. */
   readonly detached: boolean;
+  /**
+   * `rlm_query(paths=[…])` — path prefixes narrowing the child's inherited context.
+   * Absent on every other path; `llm_query` never carries it.
+   */
+  readonly paths?: readonly string[];
 }
 
 /** Handlers the bridge installs to service sub-LLM interrupts. Return the reply payload. */
@@ -94,6 +99,8 @@ export interface SandboxOptions {
 
 const WORKER_PATH = join(dirname(fileURLToPath(import.meta.url)), "worker.py");
 const STDERR_TAIL_CHARS = 8_192;
+/** How long dispose() waits for a clean worker exit before escalating to SIGKILL. */
+const SHUTDOWN_GRACE_MS = 50;
 const TODO_PROTO_KEYS = new Set(["type", "rid", "depth", "action"]);
 
 // The sandbox runs untrusted model-authored code; it must never inherit provider secrets.
@@ -105,6 +112,19 @@ function sanitizedEnv(): NodeJS.ProcessEnv {
     if (v !== undefined && !SENSITIVE_ENV.test(k)) env[k] = v;
   }
   return env;
+}
+
+/** Narrow an unknown JSON value to a frozen string array. Non-strings and blanks are dropped. */
+function toStringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = new Array<string>(value.length);
+  let n = 0;
+  for (let i = 0; i < value.length; i++) {
+    const item: unknown = value[i];
+    if (typeof item === "string" && item.trim() !== "") out[n++] = item;
+  }
+  out.length = n;
+  return n > 0 ? Object.freeze(out) : undefined;
 }
 
 const REJECT: SubLlmHandlers = {
@@ -191,11 +211,30 @@ export class PythonSandbox {
     this.proc.stdout.on("data", (chunk: string) => this.onData(chunk));
     this.proc.stderr.setEncoding("utf8");
     this.proc.stderr.on("data", (chunk: string) => this.appendStderr(chunk));
+
+    // A dead worker's pipe fails the write ASYNCHRONOUSLY: node emits 'error' on the stream, and
+    // an EventEmitter 'error' with no listener is an uncaughtException — which no try/catch
+    // around send() and no `await dispose().catch()` can intercept. Without these three
+    // listeners a worker dying mid-exec took the entire pi process down with it (EPIPE from the
+    // shutdown frame dispose() writes after the watchdog SIGKILLs).
+    // Record and swallow: the real reason is already surfaced by failAll on 'exit'.
+    const swallowPipeError = (stream: string) => (err: NodeJS.ErrnoException): void => {
+      this.appendStderr(`[rlm] worker ${stream} ${err.code ?? "error"}: ${err.message}\n`);
+    };
+    this.proc.stdin.on("error", swallowPipeError("stdin"));
+    this.proc.stdout.on("error", swallowPipeError("stdout"));
+    this.proc.stderr.on("error", swallowPipeError("stderr"));
+
     this.proc.on("error", (err: NodeJS.ErrnoException) => {
       const hint = err.code === "ENOENT" ? ` ('${python}' not found — is Python installed and on PATH?)` : "";
       this.failAll(new Error(`failed to start sandbox${hint}: ${err.message}`));
     });
-    this.proc.on("exit", () => this.failAll(new Error(`worker exited; stderr=${this.stderr.trim()}`)));
+    // Name the cause: a SIGKILL (watchdog, abort, OOM killer) reads very differently from a
+    // Python-level crash, and this message is what reaches the user as `REPL error: …`.
+    this.proc.on("exit", (code, signal) => this.failAll(new Error(
+      `worker exited (${signal !== null ? `signal ${signal}` : `code ${code}`}); `
+      + `stderr=${this.stderr.trim()}`,
+    )));
 
     this.ready = this.waitForInit();
 
@@ -224,31 +263,27 @@ export class PythonSandbox {
     return sandbox;
   }
 
+  /**
+   * Load a payload whose pin this sandbox does not own — it acquires and releases one itself.
+   * Used by SandboxManager and tests; the engine owns its run's pin and calls the pinned form.
+   */
   async loadContext(payload: unknown): Promise<number> {
-    const isJson = typeof payload !== "string";
-    let path: string | undefined;
+    const pinned = await pinContext(payload);
     try {
-      path = await this.writeContextFile(payload, isJson);
-      const res = await this.request({ type: "load_context", path, json: isJson });
-      if (!res.ok) throw new Error(res.error ?? "load_context failed");
-      return res.index ?? 0;
+      return await this.loadContextPinned(pinned);
     } finally {
-      if (path) await unlink(path).catch(() => {});
+      await pinned.release();
     }
   }
 
-  private async writeContextFile(payload: unknown, isJson: boolean): Promise<string> {
-    const file = join(
-      tmpdir(),
-      `rlm-ctx-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${isJson ? "json" : "txt"}`,
-    );
-    try {
-      await writeFile(file, isJson ? JSON.stringify(payload) : (payload as string));
-    } catch (e) {
-      await unlink(file).catch(() => {});
-      throw e;
-    }
-    return file;
+  /**
+   * Load from a pin the CALLER owns and will release. Keeping ownership outside means a run and
+   * every child that inherits its payload share one serialization and one file.
+   */
+  async loadContextPinned(pinned: PinnedContext): Promise<number> {
+    const res = await this.request({ type: "load_context", path: pinned.path, json: pinned.json });
+    if (!res.ok) throw new Error(res.error ?? "load_context failed");
+    return res.index ?? 0;
   }
 
   async exec(code: string, signal?: AbortSignal): Promise<ReplResult> {
@@ -268,12 +303,18 @@ export class PythonSandbox {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
-    try {
+    // Handshake only a live worker. The watchdog SIGKILLs before SandboxManager's catch calls
+    // dispose(), and writing the shutdown frame to a process that is already dead is exactly
+    // what produced the EPIPE that killed the host. Skipping it also drops a pointless 50ms
+    // wait from every dead-worker teardown.
+    if (this.workerAlive) {
       this.send({ id: "_shutdown", type: "shutdown" });
-    } catch {
-      /* pipe may already be gone */
+      // Wait for the worker to actually go rather than sleeping a fixed 50ms: this returns the
+      // instant it exits (the common case) and still gives up promptly if it never will, in
+      // which case the SIGKILL below finishes the job.
+      await once(this.proc, "exit", { signal: AbortSignal.timeout(SHUTDOWN_GRACE_MS) })
+        .catch(() => { /* did not exit in time — SIGKILL below */ });
     }
-    await new Promise((r) => setTimeout(r, 50));
     if (this.proc.exitCode === null) this.proc.kill("SIGKILL");
     this.failAll(new Error("sandbox disposed"));
   }
@@ -320,6 +361,13 @@ export class PythonSandbox {
   private request(payload: RequestBody, signal?: AbortSignal): Promise<WorkerResponse> {
     if (this.disposed) return Promise.reject(new Error("sandbox disposed"));
     if (signal?.aborted) return Promise.reject(new Error("repl execution aborted"));
+    // Reject before registering the pending entry: `send` no-ops for a dead worker, so a request
+    // queued here would otherwise sit until the watchdog fired instead of failing now.
+    if (!this.workerAlive) {
+      return Promise.reject(new Error(
+        `worker is not running (${this.exitDescription()}); request '${payload.type}' not sent`,
+      ));
+    }
     const id = `r${++this.seq}`;
     return new Promise<WorkerResponse>((resolve, reject) => {
       const timer = this.createWatchdog(id, payload.type, reject);
@@ -375,7 +423,45 @@ export class PythonSandbox {
         rid: "rid" in msg ? msg.rid : undefined,
       });
     }
+    // Never write to a corpse. The write would fail asynchronously and, historically, take the
+    // host process with it; even with the stdin 'error' listener in place there is nothing to
+    // gain. MUST NOT throw — `reply()` calls this from serviceInterrupt's catch, where a throw
+    // would become an unhandled rejection, trading one crash for another.
+    if (!this.workerAlive) {
+      this.appendStderr(`[rlm] dropped '${msg.type}' frame: worker ${this.exitDescription()}\n`);
+      return;
+    }
     this.proc.stdin.write(`${JSON.stringify(msg)}\n`);
+  }
+
+  /**
+   * Listener counts on the worker's stdio pipes. Exposed for tests.
+   *
+   * The `'error'` listener on each is load-bearing: an EventEmitter `'error'` with no listener is
+   * an uncaughtException, so a failed write to a dead worker's stdin kills the HOST process. That
+   * cannot be behaviour-tested reliably — whether the write reaches the syscall depends on
+   * whether node has reaped the child yet — so the invariant is asserted structurally.
+   */
+  get pipeErrorListenerCounts(): Readonly<Record<"stdin" | "stdout" | "stderr", number>> {
+    return Object.freeze({
+      stdin: this.proc.stdin.listenerCount("error"),
+      stdout: this.proc.stdout.listenerCount("error"),
+      stderr: this.proc.stderr.listenerCount("error"),
+    });
+  }
+
+  /** False once the worker is gone — exited, signalled, or its stdin torn down. */
+  private get workerAlive(): boolean {
+    return this.proc.exitCode === null
+      && this.proc.signalCode === null
+      && this.proc.stdin.writable;
+  }
+
+  /** How the worker went away, for diagnostics. */
+  private exitDescription(): string {
+    if (this.proc.signalCode !== null) return `killed by ${this.proc.signalCode}`;
+    if (this.proc.exitCode !== null) return `exited with code ${this.proc.exitCode}`;
+    return "stdin closed";
   }
 
   private onData(chunk: string): void {
@@ -432,7 +518,13 @@ export class PythonSandbox {
   private async serviceInterrupt(msg: WorkerInterrupt): Promise<void> {
     const h = this.handlers;
     const d = msg.depth;
-    const opts: SubcallOpts = { detached: msg.detached === true };
+    const opts: SubcallOpts = Object.freeze({
+      detached: msg.detached === true,
+      // Only the recursive kinds carry a context slice; the value crossed JSON, so guard it.
+      paths: msg.type === "rlm_query" || msg.type === "rlm_query_batched"
+        ? toStringArray(msg.paths)
+        : undefined,
+    });
     try {
       if (msg.type === "llm_query") {
         const response = await h.llmQuery(msg.prompt ?? "", msg.model ?? null, d, opts);
@@ -474,8 +566,7 @@ export class PythonSandbox {
             path_prefix: lib.pathPrefix,
           });
         } else {
-          const isJson = typeof lib.payload !== "string";
-          const path = await this.writeContextFile(lib.payload, isJson);
+          const { path, json: isJson } = await writeContextTempFile(lib.payload);
           // Worker reads then unlinks (worker._load_library). Host must not unlink here —
           // if the worker is SIGKILLed before os.remove, the temp file leaks in tmpdir (acceptable).
           this.reply(msg.rid, {

--- a/pi-plugin/rlm/src/sandbox/worker.py
+++ b/pi-plugin/rlm/src/sandbox/worker.py
@@ -376,6 +376,19 @@ def _stall_alarm(exec_timeout_s: float, stall_timeout_s: float):
                 signal.setitimer(signal.ITIMER_REAL, remaining)
 
 
+def _clean_paths(paths: Any) -> list[str] | None:
+    """Normalize a `paths=` argument to a non-empty list of prefixes, or None.
+
+    Shared by the single and batched rlm_query builders so the accepted shapes stay identical.
+    A bare string is treated as one prefix — the most common typo, and harmless to allow.
+    """
+    if paths is None:
+        return None
+    seq = [paths] if isinstance(paths, str) else list(paths)
+    out = [str(p).strip() for p in seq if str(p).strip()]
+    return out or None
+
+
 def _surfaced_error(message: str) -> str:
     """The "Error: …" contract value, ALSO written to the cell's stderr.
 
@@ -667,17 +680,21 @@ class Worker:
 
     # ---- spawn / await ---------------------------------------------------------------------
 
-    def _start_prompt(self, kind: str, prompt, model) -> Task:
+    def _start_prompt(self, kind: str, prompt, model, paths=None) -> Task:
         text = str(prompt)
         # A sub-LLM asked nothing answers something: the confabulation then sits in `answers`
         # looking exactly like data. Refuse instead of spending a call on it.
         if not text.strip():
             return Task.resolved(self, kind, _surfaced_error(
                 f"{kind}() got an empty prompt — a sub-LLM would confabulate an answer to nothing"))
-        rid = self._post(kind, {"prompt": text, "model": model})
+        payload: dict[str, Any] = {"prompt": text, "model": model}
+        clean = _clean_paths(paths)
+        if clean is not None:
+            payload["paths"] = clean
+        rid = self._post(kind, payload)
         return Task(self, kind, (rid,), _reduce_one, text[:40])
 
-    def _start_prompts(self, kind: str, prompts, model) -> Task:
+    def _start_prompts(self, kind: str, prompts, model, paths=None) -> Task:
         prompts = [str(p) for p in prompts]
         if not prompts:
             return Task.resolved(self, kind, [])
@@ -686,20 +703,26 @@ class Worker:
             return Task.resolved(self, kind, [
                 _surfaced_error(f"{kind}() got only empty prompts")
             ] * len(prompts))
-        rid = self._post(kind, {"prompts": prompts, "model": model})
+        payload: dict[str, Any] = {"prompts": prompts, "model": model}
+        # One prefix set for the whole batch: a per-prompt aligned list is an API nobody uses
+        # correctly, and every prompt in a batch is asking about the same slice anyway.
+        clean = _clean_paths(paths)
+        if clean is not None:
+            payload["paths"] = clean
+        rid = self._post(kind, payload)
         return Task(self, kind, (rid,), _reduce_batch(len(prompts)), f"×{len(prompts)}")
 
     def _start_llm_query(self, prompt, model: str | None = None) -> Task:
         return self._start_prompt("llm_query", prompt, model)
 
-    def _start_rlm_query(self, prompt, model: str | None = None) -> Task:
-        return self._start_prompt("rlm_query", prompt, model)
+    def _start_rlm_query(self, prompt, model: str | None = None, paths=None) -> Task:
+        return self._start_prompt("rlm_query", prompt, model, paths)
 
     def _start_llm_query_batched(self, prompts, model: str | None = None) -> Task:
         return self._start_prompts("llm_query_batched", prompts, model)
 
-    def _start_rlm_query_batched(self, prompts, model: str | None = None) -> Task:
-        return self._start_prompts("rlm_query_batched", prompts, model)
+    def _start_rlm_query_batched(self, prompts, model: str | None = None, paths=None) -> Task:
+        return self._start_prompts("rlm_query_batched", prompts, model, paths)
 
     def _start_llm_query_chunked(self, text, prompt: str, model: str | None = None) -> Task:
         """Split oversized text into cap-sized chunks and post EVERY batch at once.
@@ -1020,8 +1043,8 @@ class Worker:
         return self._await_task(self._start_llm_query_chunked(text, prompt, model))
 
     @_spawnable("rlm_query")
-    def _rlm_query(self, prompt: str, model: str | None = None) -> str:
-        return self._await_task(self._start_rlm_query(prompt, model))
+    def _rlm_query(self, prompt: str, model: str | None = None, paths=None) -> str:
+        return self._await_task(self._start_rlm_query(prompt, model, paths))
 
     def _ask_user_question(self, questions: list[dict]) -> list[dict]:
         """Present structured questions to the user; blocks until answered.
@@ -1124,7 +1147,13 @@ class Worker:
         return self._append_library(str(source), payload, r)
 
     def _append_library(self, source: str, payload: Any, meta: dict[str, Any]) -> dict[str, Any] | str:
-        """Append host-packed library files into `context` (idempotent by path prefix)."""
+        """Append host-packed library files into `context` (idempotent by path prefix).
+
+        The two refusals below are pre-flighted host-side by LIST_CONTEXT_REQUIRED /
+        NO_FILES_PRODUCED in src/bridge/library.ts, so the host never commits a sidecar index or
+        loaded-prefix for an append that fails here. Reaching either one means host and worker
+        disagree about `context`; keep the wording identical to its twin.
+        """
         ctx = self.ns.get("context")
         if not isinstance(ctx, list):
             kind = type(ctx).__name__ if ctx is not None else "None"
@@ -1229,8 +1258,8 @@ class Worker:
         return response if isinstance(response, str) else "ok"
 
     @_spawnable("rlm_query_batched")
-    def _rlm_query_batched(self, prompts, model: str | None = None) -> list[str]:
-        return self._await_task(self._start_rlm_query_batched(prompts, model))
+    def _rlm_query_batched(self, prompts, model: str | None = None, paths=None) -> list[str]:
+        return self._await_task(self._start_rlm_query_batched(prompts, model, paths))
 
     # ---- context + execution --------------------------------------------------------------
 

--- a/pi-plugin/rlm/src/text/tokens.ts
+++ b/pi-plugin/rlm/src/text/tokens.ts
@@ -21,11 +21,37 @@ export function estimateMessageTokens(messages: { content: string }[]): number {
   return estimateTokens(chars);
 }
 
-/** Total character length of a context payload (string or list of strings). */
+/**
+ * Character length of one context entry. `ContextFile`-shaped entries report their content
+ * length; anything else falls back to its serialized form.
+ *
+ * Deliberately does NOT import `isContextFile` from context/library-context.ts: that module
+ * imports `estimateTokens` from here, so the reverse import would be a cycle. `in`-narrowing
+ * needs no type guard and no cast.
+ */
+function entryLength(entry: unknown): number {
+  if (typeof entry === "string") return entry.length;
+  if (entry !== null && typeof entry === "object" && "content" in entry) {
+    const content: unknown = entry.content;
+    if (typeof content === "string") return content.length;
+  }
+  return JSON.stringify(entry ?? "").length;
+}
+
+/**
+ * Total character length of a context payload (string, file bundle, or arbitrary value).
+ *
+ * The array branch must read each entry's `content`: `String(fileEntry)` yields
+ * "[object Object]" (15 chars), which under-reported a packed repository by ~200x. This number
+ * is what buildMetadataLine tells the model to size its batches against, and it is replayed
+ * into the rebuilt system prompt on resume, so it has to be real.
+ */
 export function contextLength(context: unknown): number {
   if (typeof context === "string") return context.length;
-  if (Array.isArray(context)) return context.reduce<number>((n, x) => n + String(x).length, 0);
-  return JSON.stringify(context ?? "").length;
+  if (!Array.isArray(context)) return JSON.stringify(context ?? "").length;
+  let total = 0; // running sum — no intermediate array, no per-entry closure
+  for (let i = 0; i < context.length; i++) total += entryLength(context[i]);
+  return total;
 }
 
 /** Human label for a context payload's type, used in the metadata prompt. */

--- a/pi-plugin/rlm/src/tool/repl-tool.ts
+++ b/pi-plugin/rlm/src/tool/repl-tool.ts
@@ -22,6 +22,7 @@ import type { Model, Usage, Api } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { buildInteractiveHandlers } from "../bridge/interactive.ts";
 import { buildLibraryHandler } from "../bridge/library.ts";
+import { libraryPrefixesIn } from "../context/library-context.ts";
 import { createPiInteractiveDeps } from "../bridge/pi-interactive.ts";
 import type { SubcallGates } from "../util/concurrency.ts";
 import { LimitGuard, limitsFromConfig } from "../core/limits.ts";
@@ -234,6 +235,10 @@ export function createReplTool(deps: ReplToolDeps): ToolDefinition<typeof ReplTo
     signal,
     onUsage,
     runChild,
+    // The session sandbox's context is the child's world. Read lazily so a load_library from an
+    // earlier repl() reaches a child spawned in a later one. Populated before any interrupt can
+    // fire: execute() awaits ensureContext() before getOrCreate().
+    getChildContext: () => sandboxManager.contextPayload ?? undefined,
     trackDetached: (task) => background.track(task),
   });
 
@@ -241,12 +246,23 @@ export function createReplTool(deps: ReplToolDeps): ToolDefinition<typeof ReplTo
     ? buildLibraryHandler({
         getCwd: () => sessionCwd,
         getEmitter: () => bridgeState.currentEmitter,
+        // Refuse pre-flight whatever the worker would reject, so host idempotency is never
+        // committed for an append that did not happen.
+        getContext: () => sandboxManager.contextPayload,
         parentId: undefined,
         signal,
         startIndex: 1,
+        // Keep the manager's replay copy in step with the worker's live `context`, and with it
+        // whatever a child spawned after this load will inherit.
+        onLoaded: (_index, payload) => { sandboxManager.appendLibrary(payload); },
       })
     : undefined;
-  if (libraryBundle) deps.registerDiscardHook?.(libraryBundle.reset);
+  if (libraryBundle) {
+    // Re-derive the loaded-prefix cache from the payload that will actually be replayed —
+    // clearing it outright would make the host re-clone a library the recreated worker already has.
+    const bundle = libraryBundle;
+    deps.registerDiscardHook?.(() => bundle.reset(libraryPrefixesIn(sandboxManager.contextPayload)));
+  }
 
   return {
     name: "repl",

--- a/pi-plugin/rlm/src/ui/config-panel.ts
+++ b/pi-plugin/rlm/src/ui/config-panel.ts
@@ -10,6 +10,7 @@ const CHOICES = Object.freeze({
   maxIterations: Object.freeze(["10", "20", "30", "50"]),
   execTimeoutS: Object.freeze(["30", "60", "120", "300"]),
   maxConcurrentSubcalls: Object.freeze(["2", "4", "8", "16"]),
+  maxConcurrentChildren: Object.freeze(["1", "2", "3", "4", "6"]),
   maxBudgetUsd: Object.freeze(["none", "0.50", "1", "5"]),
   maxTimeoutMs: Object.freeze(["none", "60", "120", "300"]),
   maxTokens: Object.freeze(["none", "10000", "50000", "100000"]),
@@ -43,6 +44,7 @@ export async function showConfigPanel(ctx: ExtensionContext, config: RlmConfig):
     item("maxIterations", "Max iterations", String(config.maxIterations), CHOICES.maxIterations, "Maximum root REPL turns before RLM asks the model for a final answer."),
     item("execTimeoutS", "REPL block timeout (s)", String(config.execTimeoutS), CHOICES.execTimeoutS, "Wall-clock limit for one model-authored Python REPL block."),
     item("maxConcurrentSubcalls", "Max concurrent sub-calls", String(config.maxConcurrentSubcalls), CHOICES.maxConcurrentSubcalls, "Concurrency pool size for llm_query_batched and rlm_query_batched."),
+    item("maxConcurrentChildren", "Max concurrent children", String(config.maxConcurrentChildren), CHOICES.maxConcurrentChildren, "Concurrent rlm_query child engines per depth. Each is a Python process holding its own copy of the inherited context."),
     item("maxBudgetUsd", "Budget ceiling (USD)", config.maxBudgetUsd != null ? String(config.maxBudgetUsd) : "none", CHOICES.maxBudgetUsd, "Total spend cap for the whole recursive tree; none disables the cap."),
     item("maxTimeoutMs", "Wall-clock ceiling (min)", config.maxTimeoutMs != null ? String(Math.round(config.maxTimeoutMs / 60_000)) : "none", CHOICES.maxTimeoutMs, "Total runtime cap for the whole recursive tree; none disables the cap."),
     item("maxTokens", "Token ceiling", config.maxTokens != null ? String(config.maxTokens) : "none", CHOICES.maxTokens, "Total input+output token cap for the whole recursive tree."),
@@ -101,6 +103,7 @@ export function applySetting(config: RlmConfig, id: string, value: string): RlmC
     case "maxIterations": return Object.freeze({ ...config, maxIterations: Number(value) });
     case "execTimeoutS": return Object.freeze({ ...config, execTimeoutS: Number(value) });
     case "maxConcurrentSubcalls": return Object.freeze({ ...config, maxConcurrentSubcalls: Number(value) });
+    case "maxConcurrentChildren": return Object.freeze({ ...config, maxConcurrentChildren: Number(value) });
     case "maxBudgetUsd": return Object.freeze({ ...config, maxBudgetUsd: optionalNumber(value) });
     case "maxTimeoutMs": return Object.freeze({ ...config, maxTimeoutMs: optionalNumber(value, 60_000) });
     case "maxTokens": return Object.freeze({ ...config, maxTokens: optionalNumber(value) });

--- a/pi-plugin/rlm/src/util/concurrency.ts
+++ b/pi-plugin/rlm/src/util/concurrency.ts
@@ -80,10 +80,14 @@ export interface SubcallGates {
 }
 
 /**
- * Worst case is `maxDepth × limit` concurrent child engines (each owning a Python
- * subprocess) plus `limit` leaf completions, so keep `limit` modest — see
- * DEFAULT_CONFIG.maxConcurrentSubcalls.
+ * Worst case is `(maxDepth - 1) × childLimit` concurrent child engines — the cap short-circuits
+ * at `childDepth >= maxDepth`, so engines exist at depths 1..maxDepth-1 — plus `leafLimit` leaf
+ * completions.
+ *
+ * Children get their own, smaller bound because they are far heavier than leaves: each owns a
+ * Python subprocess AND its own copy of the context it inherited from its parent, where a leaf
+ * is one HTTP request. See DEFAULT_CONFIG.maxConcurrentChildren.
  */
-export function createSubcallGates(limit: number): SubcallGates {
-  return Object.freeze({ leaf: new Semaphore(limit), rlm: new DepthGates(limit) });
+export function createSubcallGates(leafLimit: number, childLimit: number = leafLimit): SubcallGates {
+  return Object.freeze({ leaf: new Semaphore(leafLimit), rlm: new DepthGates(childLimit) });
 }

--- a/pi-plugin/rlm/test/helpers.ts
+++ b/pi-plugin/rlm/test/helpers.ts
@@ -1,3 +1,15 @@
+/**
+ * Shared test utilities.
+ *
+ * The mock model / registry / usage / repl-fence fixtures below were duplicated per suite; they
+ * live here so a suite that needs to drive a real engine without a network does not re-declare
+ * them. Keep new fixtures here rather than copying them into a second suite.
+ */
+
+import type { Api, Model, Usage } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { RlmResult } from "../src/core/types.ts";
+
 let failures = 0;
 
 export function check(name: string, cond: boolean, extra = ""): void {
@@ -11,4 +23,44 @@ export function fail(): void {
 
 export function failureCount(): number {
   return failures;
+}
+
+/** A usage record that costs nothing — for scripted completions that never hit a provider. */
+export const ZERO_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+export const MOCK_MODEL = {
+  id: "mock",
+  provider: "test",
+  api: "openai-completions" as const,
+  name: "mock",
+  baseUrl: "http://localhost",
+  reasoning: false,
+  input: ["text"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4096,
+} as unknown as Model<Api>;
+
+export const MOCK_REGISTRY = {
+  getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "x", headers: {} }),
+  find: () => undefined,
+} as unknown as ModelRegistry;
+
+/** Wrap code in the fenced block the engine's turn parser looks for. */
+export function repl(code: string): string {
+  return "```repl\n" + code + "\n```";
+}
+
+/** A zero-cost child result, for tests that only care about the RlmInput a child received. */
+export function emptyChildResult(answer = "child"): RlmResult {
+  return Object.freeze({
+    answer, iterations: 1, costUsd: 0, inputTokens: 0, outputTokens: 0, durationMs: 0,
+  });
 }

--- a/pi-plugin/rlm/test/native-mode.ts
+++ b/pi-plugin/rlm/test/native-mode.ts
@@ -8,6 +8,7 @@
 
 import { check, fail, failureCount } from "./helpers.ts";
 import { SandboxManager } from "../src/sandbox/sandbox-manager.ts";
+import { PythonSandbox } from "../src/sandbox/sandbox.ts";
 import { formatForLLM } from "../src/context/repomix-context.ts";
 import { buildNativeSystemPrompt } from "../src/prompts/system.ts";
 import { buildReplResultText, collectReplWarnings } from "../src/tool/repl-tool.ts";
@@ -162,13 +163,107 @@ async function testSandboxManager() {
   const alive = await mgr.exec("print(callable(llm_query), callable(SHOW_VARS), callable(load_library))");
   check("SandboxManager — core REPL surface intact", !alive.raised && alive.stdout.includes("True True True"));
 
-  // Idempotent dispose
+  // ── appendLibrary keeps the replay copy truthful across a death-recreate ──
+  // Before this, contextPayload was written once and never grew, so a recreate silently rolled
+  // the sandbox back to a repo-only context and any child inheriting it never saw the library.
+  mgr.contextPayload = [{ path: "repo.ts", content: "r", tokens: 1 }];
+  mgr.appendLibrary([{ path: "lib/x-9f3a/a.ts", content: "lib content", tokens: 1 }]);
+  check(
+    "SandboxManager — appendLibrary grows the replay payload",
+    Array.isArray(mgr.contextPayload) && mgr.contextPayload.length === 2,
+    Array.isArray(mgr.contextPayload) ? `len=${mgr.contextPayload.length}` : "not array",
+  );
+  mgr.appendLibrary([{ path: "lib/x-9f3a/a.ts", content: "lib content", tokens: 1 }]);
+  check(
+    "SandboxManager — appendLibrary dedups by lib/<id>/ prefix",
+    Array.isArray(mgr.contextPayload) && mgr.contextPayload.length === 2,
+    Array.isArray(mgr.contextPayload) ? `len=${mgr.contextPayload.length}` : "not array",
+  );
+
+  // Kill the worker so the next getOrCreate recreates it, then prove the library came back.
+  const discardsBeforeKill = discardedCount;
+  await mgr.exec("import os; os._exit(1)").catch(() => {});
+  check(
+    "SandboxManager — worker death fires the discard hook",
+    discardedCount === discardsBeforeKill + 1,
+    String(discardedCount),
+  );
+  await mgr.getOrCreate({});
+  const replayed = await mgr.exec(
+    "print(len(context), any(f['path'].startswith('lib/x-9f3a/') for f in context))",
+  );
+  check(
+    "SandboxManager — recreate replays the merged payload, library included",
+    replayed.stdout.includes("2 True"),
+    replayed.stdout.trim() || replayed.stderr.slice(0, 80),
+  );
+
+  // Idempotent dispose. Counted as a delta: the death-recreate above legitimately discards too.
+  const discardsBeforeDispose = discardedCount;
   await mgr.dispose();
   check("SandboxManager — not alive after dispose", !mgr.isAlive);
-  check("SandboxManager — discard callback fires on dispose", discardedCount === 1, String(discardedCount));
+  check("SandboxManager — discard callback fires on dispose",
+    discardedCount === discardsBeforeDispose + 1, String(discardedCount));
   await mgr.dispose(); // second dispose should not throw
   check("SandboxManager — double dispose safe", true);
-  check("SandboxManager — double dispose does not double discard", discardedCount === 1, String(discardedCount));
+  check("SandboxManager — double dispose does not double discard",
+    discardedCount === discardsBeforeDispose + 1, String(discardedCount));
+}
+
+/**
+ * A failed write to a dead worker's stdin fails ASYNCHRONOUSLY: node emits 'error' on the stream,
+ * and an EventEmitter 'error' with no listener is an uncaughtException — it killed the whole host
+ * process (EPIPE from the shutdown frame dispose() writes after the watchdog SIGKILLs).
+ *
+ * This is asserted structurally, not behaviourally, and deliberately so: whether the write ever
+ * reaches the syscall depends on whether node has reaped the child yet, so a behavioural test
+ * passes with or without the fix and proves nothing. The listeners are the invariant.
+ */
+async function testPipeErrorListeners() {
+  const sb = await PythonSandbox.spawn({ python: "python3", execTimeoutS: 30 });
+  try {
+    const counts = sb.pipeErrorListenerCounts;
+    check("stdin has an 'error' listener (else a dead pipe kills the host)", counts.stdin > 0,
+      `stdin=${counts.stdin}`);
+    check("stdout has an 'error' listener", counts.stdout > 0, `stdout=${counts.stdout}`);
+    check("stderr has an 'error' listener", counts.stderr > 0, `stderr=${counts.stderr}`);
+  } finally {
+    await sb.dispose();
+  }
+}
+
+/**
+ * The watchdog SIGKILLs the worker, then SandboxManager's catch disposes it and the next call
+ * recreates. Covers the reporting and recovery half of that path — see testPipeErrorListeners
+ * for the crash-safety half.
+ */
+async function testWatchdogKillRecovers() {
+  const wd = new SandboxManager({
+    execTimeoutS: 30,
+    requestTimeoutMs: 400,
+    python: "python3",
+    sandboxInitTimeoutMs: 30_000,
+    maxPromptChars: 400_000,
+    awaitTimeoutS: 10,
+  });
+  await wd.getOrCreate({});
+
+  let killMsg = "";
+  try {
+    await wd.exec("import time; time.sleep(10)");
+  } catch (e: unknown) {
+    killMsg = e instanceof Error ? e.message : String(e);
+  }
+  check(
+    "watchdog reports why the worker was killed",
+    killMsg.includes("exceeded") && killMsg.includes("worker killed"),
+    killMsg.slice(0, 90),
+  );
+
+  await wd.getOrCreate({});
+  const revived = await wd.exec("print('recreated')");
+  check("sandbox recreates after a watchdog kill", revived.stdout.includes("recreated"));
+  await wd.dispose();
 }
 
 // ── Main ──
@@ -188,6 +283,8 @@ async function main() {
   console.log("\n─── SandboxManager ───");
   try {
     await testSandboxManager();
+    await testPipeErrorListeners();
+    await testWatchdogKillRecovers();
   } catch (err) {
     console.error("SandboxManager tests failed:", err instanceof Error ? err.message : String(err));
     fail();

--- a/pi-plugin/rlm/test/phase-batch-gate.ts
+++ b/pi-plugin/rlm/test/phase-batch-gate.ts
@@ -123,5 +123,41 @@ const single = await Promise.race([
 ]);
 check("single llm_query still completes", single === "ok", single.slice(0, 60));
 
+// ── children are bounded separately from leaves ──
+// Each child engine is a Python subprocess holding its own copy of the context it inherited,
+// so a shared limit with leaf HTTP calls over-admits them badly.
+const CHILD_LIMIT = 2;
+const childGates = createSubcallGates(GATE_LIMIT, CHILD_LIMIT);
+let childPeak = 0;
+let childActive = 0;
+const childHandlers = createSubcallHandlers({
+  resolve: (_opts, depth) => ({ emitter, parentId: undefined, depth, limits: limitsFromRemaining() }),
+  gates: childGates,
+  registry: ModelRegistry.create(AuthStorage.create()),
+  getWorkerModel: () => fakeModel,
+  getConfig: () => ({ maxPromptChars: 400_000, maxDepth: 4 }),
+  runChild: async () => {
+    childActive += 1;
+    if (childActive > childPeak) childPeak = childActive;
+    await sleep(20);
+    childActive -= 1;
+    return { answer: "child", iterations: 1, costUsd: 0, inputTokens: 0, outputTokens: 0, durationMs: 0 };
+  },
+  degrade: async () => "degraded",
+});
+
+const childPrompts = Array.from({ length: 8 }, (_, i) => `child ${i}`);
+const childOut = await Promise.race([
+  childHandlers.rlmQueryBatched(childPrompts, null, 0, ATTACHED),
+  sleep(DEADLOCK_MS).then((): null => null),
+]);
+check("child batch completes through the per-depth gate", childOut !== null);
+check(
+  `child gate bounds concurrency at ${CHILD_LIMIT}, below the leaf limit of ${GATE_LIMIT}`,
+  childPeak > 0 && childPeak <= CHILD_LIMIT,
+  `peak=${childPeak}`,
+);
+check("leaf gate keeps its own, larger limit", peak > CHILD_LIMIT, `leaf peak=${peak}`);
+
 server.close();
 process.exit(failureCount() > 0 ? 1 : 0);

--- a/pi-plugin/rlm/test/phase-guards.ts
+++ b/pi-plugin/rlm/test/phase-guards.ts
@@ -117,6 +117,11 @@ async function main() {
     NATIVE_PROMPT_STATIC.length < NATIVE_PROMPT_BUDGET,
     `(${NATIVE_PROMPT_STATIC.length.toLocaleString()} chars; budget ${NATIVE_PROMPT_BUDGET.toLocaleString()})`,
   );
+  check(
+    "native prompt states what an rlm_query child inherits",
+    NATIVE_PROMPT_STATIC.includes("child inherits your `context`")
+      && NATIVE_PROMPT_STATIC.includes("paths="),
+  );
 
   // ── repl output cap ──
   const replCapped = capReplResultText("y".repeat(10_000));

--- a/pi-plugin/rlm/test/phase-library.ts
+++ b/pi-plugin/rlm/test/phase-library.ts
@@ -3,13 +3,18 @@
  * Run: bun run pi-plugin/rlm/test/phase-library.ts
  */
 
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { check, failureCount } from "./helpers.ts";
 import {
+  contextEntryPath,
+  filterContextByPaths,
+  isContextFile,
   libraryNamespace,
   libraryPathPrefix,
+  libraryPrefixesIn,
   librarySourceId,
   MAX_LIBRARY_FILE_BYTES,
   mergeLibraryIntoContext,
@@ -18,6 +23,7 @@ import {
   payloadPrefix,
   resolveLibrarySource,
 } from "../src/context/library-context.ts";
+import { pinContext, pinnedCount } from "../src/sandbox/context-file.ts";
 import { buildLibraryHandler } from "../src/bridge/library.ts";
 import { PythonSandbox } from "../src/sandbox/sandbox.ts";
 import { buildRlmSystemPrompt } from "../src/prompts/system.ts";
@@ -344,6 +350,127 @@ async function main() {
       "t",
     );
     check("withChars: sum of content lengths", wc.chars === 7, String(wc.chars));
+
+    // ── Phase 1a primitives ──
+    check("isContextFile: accepts a file entry",
+      isContextFile({ path: "a.ts", content: "x", tokens: 1 }));
+    check("isContextFile: rejects non-file shapes",
+      !isContextFile(null) && !isContextFile("a.ts") && !isContextFile({ path: 1, content: "x" }));
+    check("contextEntryPath: reads a path, undefined otherwise",
+      contextEntryPath({ path: "a.ts", content: "x" }) === "a.ts"
+        && contextEntryPath(42) === undefined);
+
+    check("libraryPrefixesIn: empty for a non-array", libraryPrefixesIn("plain text").length === 0);
+    const twoLibs = [
+      { path: "repo.ts", content: "r", tokens: 1 },
+      { path: "lib/one-11111111/a.ts", content: "x", tokens: 1 },
+      { path: "lib/two-22222222/b.ts", content: "y", tokens: 1 },
+      { path: "lib/one-11111111/c.ts", content: "z", tokens: 1 },
+      { path: "lib/unknown/legacy.ts", content: "w", tokens: 1 },
+    ];
+    const prefixes = libraryPrefixesIn(twoLibs);
+    check("libraryPrefixesIn: distinct prefixes, lib/unknown/ skipped",
+      prefixes.length === 2 && prefixes.includes("lib/one-11111111/")
+        && prefixes.includes("lib/two-22222222/"),
+      prefixes.join(","));
+
+    const filteredOne = filterContextByPaths(twoLibs, ["lib/one-11111111/"]);
+    check("filterContextByPaths: prefix selects its subtree",
+      filteredOne.files.length === 2 && filteredOne.unmatched.length === 0,
+      `${filteredOne.files.length} file(s)`);
+    const filteredMixed = filterContextByPaths(twoLibs, ["lib/two-22222222/", "nope/"]);
+    check("filterContextByPaths: reports prefixes that matched nothing",
+      filteredMixed.files.length === 1 && filteredMixed.unmatched.length === 1
+        && filteredMixed.unmatched[0] === "nope/",
+      filteredMixed.unmatched.join(","));
+    check("filterContextByPaths: non-array yields no files, all unmatched",
+      filterContextByPaths("text", ["a/"]).files.length === 0
+        && filterContextByPaths("text", ["a/"]).unmatched.length === 1);
+    check("filterContextByPaths: no prefixes selects nothing",
+      filterContextByPaths(twoLibs, []).files.length === 0);
+
+    // ── Accumulator: what a child inherits must grow when a library loads ──
+    let accumulated: unknown = [{ path: "repo.ts", content: "r", tokens: 1 }];
+    const accBundle = buildLibraryHandler({
+      cwd: tmp,
+      startIndex: 1,
+      getContext: () => accumulated,
+      onLoaded: (_i, payload) => { accumulated = mergeLibraryIntoContext(accumulated, payload); },
+    });
+    await accBundle.handlers.loadLibrary(pathA, 0);
+    await accBundle.handlers.loadLibrary(pathB, 0);
+    const accPrefixes = libraryPrefixesIn(accumulated);
+    check("accumulator: both libraries present after two loads", accPrefixes.length === 2,
+      accPrefixes.join(","));
+    const lenAfterTwo = Array.isArray(accumulated) ? accumulated.length : -1;
+    await accBundle.handlers.loadLibrary(pathA, 0);
+    check("accumulator: re-loading a source does not duplicate it",
+      Array.isArray(accumulated) && accumulated.length === lenAfterTwo,
+      `len=${Array.isArray(accumulated) ? accumulated.length : "n/a"}`);
+
+    // reset(keep) re-derives the cache from the payload that will be replayed, so a recreated
+    // sandbox does not re-clone what its replayed context already holds.
+    let repacks = 0;
+    const resetBundle = buildLibraryHandler({
+      cwd: tmp,
+      startIndex: 1,
+      onLoaded: () => { repacks++; },
+    });
+    await resetBundle.handlers.loadLibrary(pathA, 0);
+    resetBundle.reset(libraryPrefixesIn(accumulated));
+    check("reset(keep): re-seeds the prefix cache", resetBundle.loadedPrefixes().size === 2,
+      String(resetBundle.loadedPrefixes().size));
+    const afterReset = await resetBundle.handlers.loadLibrary(pathA, 0);
+    check("reset(keep): a kept source is alreadyLoaded without re-packing",
+      afterReset.alreadyLoaded === true && repacks === 1, `repacks=${repacks}`);
+    resetBundle.reset();
+    check("reset(): no-arg still clears, as before", resetBundle.loadedPrefixes().size === 0);
+
+    // ── Pre-flight refusals: never commit an index/prefix for an append the worker will reject ──
+    let refusedLoads = 0;
+    const refuseBundle = buildLibraryHandler({
+      cwd: tmp,
+      startIndex: 1,
+      getContext: () => "plain text",   // what a pre-#4 child had as its whole world
+      onLoaded: () => { refusedLoads++; },
+    });
+    let refusal = "";
+    try {
+      await refuseBundle.handlers.loadLibrary(pathA, 0);
+    } catch (e: unknown) {
+      refusal = e instanceof Error ? e.message : String(e);
+    }
+    check("pre-flight: non-list context is refused with the worker's exact wording",
+      refusal === "load_library requires list context (file bundle); got str", refusal);
+    check("pre-flight: nothing committed on refusal",
+      refusedLoads === 0 && refuseBundle.loadedPrefixes().size === 0);
+
+    const emptyDir = join(tmp, "empty-lib");
+    await mkdir(emptyDir, { recursive: true });
+    let emptyRefusal = "";
+    const emptyBundle = buildLibraryHandler({ cwd: tmp, startIndex: 1, getContext: () => [] });
+    try {
+      await emptyBundle.handlers.loadLibrary(emptyDir, 0);
+    } catch (e: unknown) {
+      emptyRefusal = e instanceof Error ? e.message : String(e);
+    }
+    check("pre-flight: a source that packs to nothing is refused before committing",
+      emptyRefusal.includes("produced no files") || emptyRefusal.includes("pack failed"),
+      emptyRefusal);
+    check("pre-flight: empty source consumed no prefix", emptyBundle.loadedPrefixes().size === 0);
+
+    // ── M2: concurrent pins share one write, and the file is unlinked exactly once ──
+    const payload = [{ path: "p.ts", content: "shared", tokens: 1 }];
+    const [pinA, pinB] = await Promise.all([pinContext(payload), pinContext(payload)]);
+    check("pin: concurrent holders share one file", pinA.path === pinB.path, pinA.path);
+    check("pin: content is the serialized payload",
+      JSON.parse(await readFile(pinA.path, "utf-8"))[0].content === "shared");
+    await pinA.release();
+    check("pin: file survives while a holder remains", existsSync(pinB.path));
+    await pinB.release();
+    check("pin: unlinked once the last holder releases", !existsSync(pinB.path));
+    await pinB.release(); // idempotent — must not throw or double-unlink
+    check("pin: release is idempotent", pinnedCount() === 0, String(pinnedCount()));
 
     // Live optional: real https clone
     if (process.env.RLM_TEST_LIVE === "1") {

--- a/pi-plugin/rlm/test/phase-pipeline.ts
+++ b/pi-plugin/rlm/test/phase-pipeline.ts
@@ -8,46 +8,13 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, 
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Api, Model, Usage } from "@earendil-works/pi-ai";
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
-import { check, failureCount } from "./helpers.ts";
+import { check, failureCount, MOCK_MODEL, MOCK_REGISTRY, repl, ZERO_USAGE } from "./helpers.ts";
 import { DEFAULT_CONFIG } from "../src/config/defaults.ts";
 import { createEngine } from "../src/core/engine.ts";
 import type { CompleteFn } from "../src/core/iteration.ts";
 import { RlmEmitter } from "../src/tool/rlm-events.ts";
 import { ARTIFACTS_DIR } from "../src/core/artifacts.ts";
 import type { ChatMsg } from "../src/bridge/model.ts";
-
-const ZERO_USAGE: Usage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
-
-const MOCK_MODEL = {
-  id: "mock",
-  provider: "test",
-  api: "openai-completions" as const,
-  name: "mock",
-  baseUrl: "http://localhost",
-  reasoning: false,
-  input: ["text"] as const,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-  contextWindow: 128_000,
-  maxTokens: 4096,
-} as unknown as Model<Api>;
-
-const MOCK_REGISTRY = {
-  getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "x", headers: {} }),
-  find: () => undefined,
-} as unknown as ModelRegistry;
-
-function repl(code: string): string {
-  return "```repl\n" + code + "\n```";
-}
 
 function historyBlob(messages: readonly ChatMsg[]): string {
   return messages.map((m) => m.content).join("\n");

--- a/pi-plugin/rlm/test/phase1.ts
+++ b/pi-plugin/rlm/test/phase1.ts
@@ -11,6 +11,7 @@ import { formatReplOutputs, turnHadError } from "../src/core/answer.ts";
 import { PythonSandbox } from "../src/sandbox/sandbox.ts";
 import { buildMetadataLine, buildRlmSystemPrompt } from "../src/prompts/system.ts";
 import { findReplBlocks, truncateOutput } from "../src/text/parsing.ts";
+import { contextLength } from "../src/text/tokens.ts";
 
 
 async function main() {
@@ -37,6 +38,26 @@ async function main() {
     sp.includes("grep_context(") && sp.includes("outline(") && sp.includes("BM25"));
   const childPrompt = buildRlmSystemPrompt({ contextType: "str", contextChars: 5000 }, { orchestrator: false });
   check("F1: string context prompt does not describe list[dict]", !childPrompt.includes("list[dict]") && childPrompt.includes("plain string"), childPrompt.slice(0, 120));
+  const subRlmPrompt = buildRlmSystemPrompt(
+    { contextType: "list[3]", contextChars: 5000 },
+    { orchestrator: false, child: true },
+  );
+  check("child prompt orients the sub-RLM in its parent's world",
+    subRlmPrompt.includes("You are a sub-RLM") && subRlmPrompt.includes("lib/<id>/"));
+  check("root prompt has no sub-RLM orientation",
+    !buildRlmSystemPrompt({ contextType: "list[3]", contextChars: 5000 }, {}).includes("sub-RLM"));
+
+  // contextLength must read each entry's content: String(entry) is "[object Object]" (15 chars),
+  // which under-reported a packed repository by ~200x in the number the model sizes batches by.
+  check("contextLength: string", contextLength("z".repeat(3000)) === 3000);
+  check("contextLength: file bundle sums content lengths",
+    contextLength([
+      { path: "a.ts", content: "x".repeat(1000), tokens: 250 },
+      { path: "b.ts", content: "y".repeat(2000), tokens: 500 },
+    ]) === 3000);
+  check("contextLength: degenerate entries do not throw",
+    contextLength([null, 42, "abc"]) > 0);
+
   const metadata = buildMetadataLine({ contextType: "json", contextChars: 5000 });
   check(
     "metadata describes JSON array context",

--- a/pi-plugin/rlm/test/phase4.ts
+++ b/pi-plugin/rlm/test/phase4.ts
@@ -18,8 +18,11 @@ import {
 } from "../src/bridge/subcall-handlers.ts";
 import { createSubcallGates } from "../src/util/concurrency.ts";
 import { RlmEmitter } from "../src/tool/rlm-events.ts";
-import type { RunRlm } from "../src/core/types.ts";
+import type { RlmInput, RunRlm } from "../src/core/types.ts";
 import type { SubcallOpts } from "../src/sandbox/sandbox.ts";
+import type { ContextFile } from "../src/context/repomix-context.ts";
+import type { CompleteFn } from "../src/core/iteration.ts";
+import { emptyChildResult, MOCK_MODEL, MOCK_REGISTRY, repl, ZERO_USAGE } from "./helpers.ts";
 
 /** Every sub-call in these token-free tests is synchronous, never spawn()ed. */
 const ATTACHED: SubcallOpts = { detached: false };
@@ -35,6 +38,8 @@ function rlmOnlyHandlers(opts: {
   run: RunRlm;
   degrade: Degrade;
   maxDepth: number;
+  /** Stands in for the parent's live context; omit to test the unwired fallback. */
+  childContext?: () => unknown;
   remaining?: () => { readonly budgetUsd?: number; readonly timeoutMs?: number };
   onChildUsage?: (costUsd: number, inputTokens: number, outputTokens: number) => void;
 }): SubcallHandlers {
@@ -49,6 +54,7 @@ function rlmOnlyHandlers(opts: {
     },
     getConfig: () => ({ maxPromptChars: Number.MAX_SAFE_INTEGER, maxDepth: opts.maxDepth }),
     runChild: opts.run,
+    getChildContext: opts.childContext,
     degrade: opts.degrade,
     onChildUsage: opts.onChildUsage,
   });
@@ -84,6 +90,134 @@ async function testRecursionBridge(): Promise<boolean> {
   const firstBatch = batched[0];
   const thirdBatch = batched[2];
   log("rlm_query_batched preserves order", batched.length === 3 && firstBatch !== undefined && thirdBatch !== undefined && firstBatch.includes("one") && thirdBatch.includes("three"));
+
+  return pass;
+}
+
+/**
+ * Issue #4: a child must inherit the parent's context, not receive the prompt as its world.
+ * Token-free — the recording `run` never spawns a real engine.
+ */
+async function testContextInheritance(): Promise<boolean> {
+  let pass = true;
+  const log = (n: string, ok: boolean, extra = "") => {
+    console.log(`${ok ? "✓" : "✗"} ${n}${extra ? `  — ${extra}` : ""}`);
+    if (!ok) pass = false;
+  };
+
+  const files: readonly ContextFile[] = Object.freeze([
+    Object.freeze({ path: "lib/x-9f3a/src/a.ts", content: "alpha", tokens: 1 }),
+    Object.freeze({ path: "src/auth/login.ts", content: "beta", tokens: 1 }),
+    Object.freeze({ path: "README.md", content: "gamma", tokens: 1 }),
+  ]);
+  const degrade: Degrade = async (p) => `llm(${p.slice(0, 8)})`;
+
+  const seen: RlmInput[] = [];
+  const record: RunRlm = async (input) => {
+    seen[seen.length] = input;
+    return emptyChildResult();
+  };
+
+  const inherit = rlmOnlyHandlers({ run: record, degrade, maxDepth: 2, childContext: () => files });
+  await inherit.rlmQuery("audit auth", null, 0, ATTACHED);
+  const child = seen[0];
+  log("#4: prompt becomes the child's rootPrompt", child?.rootPrompt === "audit auth");
+  log("#4: child inherits the parent context by identity", child?.context === files);
+  log("#4: child runs at depth 1", child?.depth === 1);
+
+  // Regression guard: with no provider wired the old shape (prompt-as-context) must survive,
+  // because a genuine text sub-task still has nothing else to be its world.
+  seen.length = 0;
+  const unwired = rlmOnlyHandlers({ run: record, degrade, maxDepth: 2 });
+  await unwired.rlmQuery("plain text task", null, 0, ATTACHED);
+  log("#4: unwired falls back to prompt-as-context", seen[0]?.context === "plain text task");
+
+  // paths= narrows by prefix.
+  seen.length = 0;
+  await inherit.rlmQuery("only auth", null, 0, { detached: false, paths: ["src/auth/"] });
+  const narrowed = seen[0]?.context;
+  log(
+    "#4: paths= narrows the inherited context",
+    Array.isArray(narrowed) && narrowed.length === 1
+      && (narrowed[0] as ContextFile).path === "src/auth/login.ts",
+    Array.isArray(narrowed) ? `${narrowed.length} file(s)` : typeof narrowed,
+  );
+
+  // A prefix that matches nothing must hand over everything AND say so — never blind the child.
+  seen.length = 0;
+  await inherit.rlmQuery("typo", null, 0, { detached: false, paths: ["src/nope/"] });
+  log("#4: unmatched paths fall back to the full context", seen[0]?.context === files);
+  log(
+    "#4: unmatched paths are reported in the child's prompt",
+    seen[0]?.rootPrompt.includes("matched no files") === true,
+  );
+
+  // Batched children share one prefix set.
+  seen.length = 0;
+  await inherit.rlmQueryBatched(["a", "b"], null, 0, { detached: false, paths: ["lib/x-9f3a/"] });
+  log(
+    "#4: batched children each get the narrowed slice",
+    seen.length === 2 && seen.every((s) => Array.isArray(s.context) && s.context.length === 1),
+  );
+
+  return pass;
+}
+
+/**
+ * End-to-end at depth > 0: an inherited file bundle must survive RlmInput → loadContext → the
+ * worker, and arrive as a real `list` the retrieval primitives can index.
+ *
+ * The first engine run at depth > 0 in the suite. Token-free (scripted `complete`), but it does
+ * spawn a real Python sandbox — that is the point, since the bug lived in the handoff.
+ */
+async function testChildEngineSeesInheritedContext(): Promise<boolean> {
+  let pass = true;
+  const log = (n: string, ok: boolean, extra = "") => {
+    console.log(`${ok ? "✓" : "✗"} ${n}${extra ? `  — ${extra}` : ""}`);
+    if (!ok) pass = false;
+  };
+
+  const files: readonly ContextFile[] = Object.freeze([
+    Object.freeze({ path: "lib/x-9f3a/src/a.ts", content: "alpha alpha alpha", tokens: 3 }),
+    Object.freeze({ path: "src/auth/login.ts", content: "beta", tokens: 1 }),
+    Object.freeze({ path: "README.md", content: "gamma", tokens: 1 }),
+  ]);
+
+  let turn = 0;
+  let systemPrompt = "";
+  let replEcho = "";
+  const complete: CompleteFn = async (messages) => {
+    const first = messages[0];
+    if (systemPrompt === "" && first !== undefined) systemPrompt = first.content;
+    if (turn === 0) {
+      turn += 1;
+      return {
+        text: repl('print("CTX", type(context).__name__, len(context), bool(search("alpha")))'),
+        usage: ZERO_USAGE,
+      };
+    }
+    // Turn 2 sees turn 1's REPL stdout folded into the history as a user message.
+    replEcho = messages.map((m) => m.content).join("\n");
+    return { text: repl('answer["content"] = "ok"\nanswer["ready"] = True'), usage: ZERO_USAGE };
+  };
+
+  const res = await createEngine({
+    emitter: new RlmEmitter(),
+    model: MOCK_MODEL,
+    workerModel: MOCK_MODEL,
+    registry: MOCK_REGISTRY,
+    config: { ...DEFAULT_CONFIG, maxIterations: 4, compaction: false },
+    complete,
+  })({ rootPrompt: "what is alpha?", context: files, depth: 1, parentNodeId: "n1" });
+
+  log("#4 e2e: child engine completed", res.answer === "ok", res.answer.slice(0, 80));
+  // Match the stdout line, not the assistant's echo of the code that produced it.
+  const ctxLine = replEcho.indexOf("CTX list");
+  log("#4 e2e: worker sees a list of 3 and search() hits", replEcho.includes("CTX list 3 True"),
+    ctxLine === -1 ? "no CTX stdout line" : replEcho.slice(ctxLine, ctxLine + 20));
+  log("#4 e2e: child prompt uses the file-bundle branch", systemPrompt.includes("list[dict]"));
+  log("#4 e2e: child prompt says it is a sub-RLM", systemPrompt.includes("You are a sub-RLM"));
+  log("#4 e2e: child prompt carries the question", systemPrompt.includes("what is alpha?"));
 
   return pass;
 }
@@ -186,6 +320,12 @@ function pick(reg: ModelRegistry, provider: string, id: string): Model<Api> | un
 async function main() {
   const recursionOk = await testRecursionBridge();
   if (!recursionOk) process.exit(1);
+
+  const inheritOk = await testContextInheritance();
+  if (!inheritOk) process.exit(1);
+
+  const childEngineOk = await testChildEngineSeesInheritedContext();
+  if (!childEngineOk) process.exit(1);
 
   const budgetOk = await testChildBudgetPropagation();
   if (!budgetOk) process.exit(1);


### PR DESCRIPTION
Two independent fixes; the second was found while running the first.

## Child RLM context inheritance (#4)

childRun was the single construction site of a child's RlmInput and it hardcoded `context: prompt`, so a recursive rlm_query child's entire world was the prompt string -- no repo files, no libraries, ever. load_library only made it visible: `lib/<id>/` is a virtual namespace living solely inside the context list, so a child told about those paths in prose tried to resolve them on disk, failed, and answered from general knowledge with no error surfaced.

Children now inherit the parent's live context and take the prompt as their rootPrompt, exactly as depth 0 does. This costs zero extra LLM tokens -- only a size line reaches the model; the content lives in the sandbox. The seam is one new field, getChildContext on SubcallHandlerDeps, so there is still exactly one place a child's world is built.

Three bugs the fix exposed, also closed:

- contextLength summed String(entry).length, i.e. "[object Object]" (15 chars) per file, under-reporting a packed repository ~200x. That number is what the model sizes batches against and what is replayed into the rebuilt prompt on /rlm-resume.
- load_library could report already_loaded for an append that never happened: the host committed the sidecar index and prefix on pack success while the worker could still refuse. Both worker refusals are now pre-flighted host-side with identical wording.
- Libraries were lost on sandbox death-recreate in native mode -- contextPayload was never updated after a load, so a recreate silently replayed a repo-only context.

Added: rlm_query(prompt, paths=['src/auth/']) narrows a child's inherited context by prefix, falling back to the full context and saying so when a prefix matches nothing. maxConcurrentChildren (default 3) bounds child engines separately from leaf sub-calls -- each child is a Python subprocess holding its own copy of the context, and the shared limit allowed up to 18 concurrent repository-sized workers. Context files are serialized once per payload version and shared by refcount, in bounded chunks so a large repository never blocks the event loop.

Behaviour change worth noting: a child that used to see a 2 KB prompt now sees the repository and has maxIterations to spend on it, so a fan-out of N children is N real analyses. Budget and timeout still descend as remaining amounts, so the tree cannot exceed the root cap.

## A dying worker took the whole session down

PythonSandbox attached listeners to the child process and to stdout/stderr but never to proc.stdin. A write to a dead worker's pipe fails asynchronously: node emits 'error' on the stream, and an EventEmitter 'error' with no listener is an uncaughtException -- which neither the try/catch around send() nor the one around dispose() can intercept. The deterministic route in: the request watchdog SIGKILLs the worker, SandboxManager disposes it, dispose() writes a shutdown frame to the corpse, write EPIPE, process exit -- losing session history and REPL state over a worker that was meant to be disposable.

Every stdio pipe now has an 'error' listener recording to the bounded stderr tail; send() drops frames for a dead worker instead of writing (and never throws, since reply() calls it from a catch block); request() rejects up front rather than waiting for the watchdog; dispose() handshakes only a live worker and waits for its actual exit event instead of sleeping a fixed 50ms. The exit handler now reports signal vs code, so the surviving `REPL error:` distinguishes a watchdog kill, an abort, an OOM kill and a Python-level crash.

Crash-safety is asserted structurally (pipeErrorListenerCounts) rather than behaviourally, and deliberately: whether the write reaches the syscall depends on whether node has reaped the child yet, so a behavioural test passes with or without the fix. The suite also runs under bun, whose stream internals do not raise this EPIPE at all.

## Verification

bun run check clean; all 21 suites pass. New coverage includes the first engine run at depth > 0 in the repo, asserting an inherited bundle survives RlmInput -> loadContext -> worker.

Known and deliberately out of scope: the request watchdog is only refreshed by frames arriving at that sandbox, so a slow leaf llm_query batch can still trip requestTimeoutMs and SIGKILL a healthy worker. Its symptom is now a clear REPL error rather than a dead session.

Fixes https://github.com/openzebra/rlm.pi/issues/4