### PR TITLE
fix: handle empty chunked replies in llm_query_chunked/map_files

### DIFF
--- a/pi-plugin/rlm/src/sandbox/py/tasks.py
+++ b/pi-plugin/rlm/src/sandbox/py/tasks.py
@@ -41,14 +41,27 @@ def _reduce_batch(n: int):
     return reduce
 
 
-def _reduce_chunked(sizes: list[int]):
-    """Concatenate several llm_query_batched replies back into one flat chunk list."""
+def _reduce_chunked(sizes: list[int], drop_empty: bool = True):
+    """Concatenate several llm_query_batched replies back into one flat chunk list.
+
+    drop_empty=True (llm_query_chunked): filter "" replies so results never degrade
+    to blank entries; the flattened list may then be shorter than the chunk count,
+    so callers must consume answers in order and never index-match a chunk to a slot.
+    drop_empty=False (map_files): keep "" placeholders because _reduce_map_files
+    regroups by position — dropping an empty reply there would shift every later
+    slice and merge file contents into the wrong paths.
+    """
     per = [_reduce_batch(n) for n in sizes]
 
     def reduce(replies: list[dict[str, Any]]) -> list[str]:
+        if len(replies) != len(per):
+            return [f"Error: chunk reply count mismatch ({len(replies)} != {len(per)})"] * sum(sizes)
         out: list[str] = []
         for red, rep in zip(per, replies):
-            out.extend(red([rep]))
+            if drop_empty:
+                out.extend(x for x in red([rep]) if x)
+            else:
+                out.extend(red([rep]))
         return out
     return reduce
 
@@ -59,7 +72,7 @@ def _reduce_map_files(sizes: list[int], spans: list[tuple[str, int]]):
     A file larger than the per-prompt budget contributed several requests; its answers rejoin
     in order, which is what makes map_files a {path: answer} dict rather than a flat list.
     """
-    flatten = _reduce_chunked(sizes)
+    flatten = _reduce_chunked(sizes, drop_empty=False)
 
     def reduce(replies: list[dict[str, Any]]) -> dict[str, str]:
         responses = flatten(replies)


### PR DESCRIPTION
# PR: fix `llm_query_chunked`/`map_files` empty-reply handling (B2, rebased on 0.2.2)

**Target repo**: `openzebra/rlm.pi` · `pi-plugin/rlm`
**Base**: `master` (upstream 0.2.2)
**源**: 本地 `vendor/pi-rlm`,已同步至上游 0.2.2 基线 + 单点修复

## Summary

This PR contains **one** change, rebased on top of current upstream 0.2.2:

**B2 — `llm_query_chunked` can return blank entries for long texts, and a naive
empty filter would corrupt `map_files` grouping.** The reducer shared by both
paths never drops empty sub-LLM replies, so a `""` chunk degrades the result to
blank entries; but *filtering* in the shared reducer would be worse — `map_files`
regroups by position, so dropping an entry shifts every later file's content into
the wrong path.

The fix parameterizes the contract at the shared reducer's boundary:
- `llm_query_chunked` keeps filtering `""` (never degrades to blank entries);
- `map_files` keeps `""` placeholders (position-stable grouping);
- a reply-count guard turns a missing/extra reply into a loud `Error:` instead of
  a silent `zip` truncation.

No other changes: the other fixes we originally developed against 0.2.1 are
**already solved or superseded in 0.2.2** (see "Why only B2" below).

## Changes

| File | Change |
|---|---|
| `src/sandbox/py/tasks.py` | `_reduce_chunked(sizes, drop_empty=True)` — filters `""` when `drop_empty`, keeps placeholders otherwise; validates `len(replies) == len(sizes)` and returns `Error: chunk reply count mismatch` instead of silently truncating |
| `src/sandbox/py/tasks.py` | `_reduce_map_files` calls `_reduce_chunked(sizes, drop_empty=False)` — position-stable grouping so an empty reply never shifts later file slices |

The change is additive and backward-compatible: `_reduce_chunked(sizes)` (no
`drop_empty` arg) keeps the previous behavior (no filtering) — wait, it now
defaults to `drop_empty=True`, which is the *desired* fix for `llm_query_chunked`
(worker.py calls it without the arg). `map_files` explicitly opts into
position-stable mode.

## Verification

- Python behavior checks (fake replies with `""`):
  - `map_files` with `file_a → ""`, `file_b → [B1, B2]` returns
    `{'file_a': '', 'file_b': 'B1\n\nB2'}` — **no content shift** ✅
  - `_reduce_chunked(drop_empty=True)` filters `""` (`["X"]` from `["", "X"]`) ✅
  - `_reduce_chunked(drop_empty=False)` keeps `["", "X"]` ✅
  - missing reply returns `Error: chunk reply count mismatch (1 != 2)` ✅
- Upstream 0.2.2 test suites pass unchanged: `phase-chunked.ts`,
  `phase-library.ts`, `phase-retrieval.ts` ✅

## Why only B2 (other 0.2.1-era fixes are already upstream)

| 0.2.1 fix | Status in 0.2.2 |
|---|---|
| B1 — recursive child inherits `load_library` context | **Already fixed upstream** (#4 "Child RLM context inheritance"): children inherit the parent's live context via `getChildContext()`, zero extra LLM tokens |
| P1-4 — live handler refresh on reused sandboxes | **Already solved**: per-invocation state (emitter/limits/depth) is swapped via `execWithSetup`/`setup()`, and sandbox death-recreate rebuilds with the latest handlers |
| P1-3 — timeout scaling for large libraries | **Superseded**: 0.2.2 moved context transport to refcounted temp-file pins (`context-file.ts`) — serialization is chunked/async and shared across children, so large libraries no longer blow the per-request timeout |
| P0-1 — loud warning when libraries are lost | **Not applicable**: 0.2.2 inherits the live context through an accessor (`getChildContext`), eliminating the "parent has libraries but child doesn't" gap structurally |

## Testing notes for reviewers

1. `cd pi-plugin/rlm && bun run test/phase-chunked.ts` — must pass (upstream baseline).
2. From a RLM sandbox: `llm_query_chunked("x" * 250_000, "Q")` must return
   non-empty answers for every chunk.
3. `map_files` on 2+ files where the first file's sub-LLM returns `""` must not
   shift later files' content into the wrong paths.
