### PR TITLE
fix: bypass RLM in pi-subagents children (PI_SUBAGENT_CHILD)

### DIFF
--- a/pi-plugin/rlm/src/index.ts
+++ b/pi-plugin/rlm/src/index.ts
@@ -24,7 +24,29 @@ const BLOCKED_NATIVE_TOOLS = Object.freeze(new Set(["read", "grep"]));
 const WATCHDOG_HEARTBEAT_MS = 30_000;
 const CAPPED_RESULT_TOOLS = Object.freeze(new Set(["bash", "find", "ls"]));
 
+// ── Subagent isolation ────────────────────────────────────────────────────────
+// pi-subagents spawns each child as a standalone pi process built around native
+// file tools (read/grep/bash). RLM's contract is the opposite: it blocks those
+// tools and routes reading through `repl`, which (a) needs the repo pre-packed
+// via repomix and (b) is not injected into the child's tool allowlist by
+// pi-subagents. Forcing RLM onto a subagent child therefore leaves it unable to
+// read anything. Bypass RLM entirely in children; the parent session keeps full
+// RLM behaviour. Set PI_RLM_FORCE_IN_SUBAGENT=1 to opt a child back in
+// (experimental — the child must then be able to pack its own cwd).
+const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
+const RLM_FORCE_IN_SUBAGENT_ENV = "PI_RLM_FORCE_IN_SUBAGENT";
+
+/** True inside a pi-subagents child that should NOT activate RLM. Exported for tests. */
+export function isSubagentChildBypass(): boolean {
+  return process.env[SUBAGENT_CHILD_ENV] === "1"
+    && process.env[RLM_FORCE_IN_SUBAGENT_ENV] !== "1";
+}
+
 export default function rlmExtension(pi: ExtensionAPI): void {
+  // Subagent children run pi-subagents' native tool flow; RLM is a parent-session
+  // optimisation that breaks the child's tool contract. See isSubagentChildBypass().
+  if (isSubagentChildBypass()) return;
+
   // Init synchronously with defaults — ensures commands/tools/handlers register before session_start
   const config = mergeConfig({});
   const controller = new RlmController(config);

--- a/pi-plugin/rlm/test/subagent-bypass.ts
+++ b/pi-plugin/rlm/test/subagent-bypass.ts
@@ -1,0 +1,98 @@
+/**
+ * Subagent-child bypass tests.
+ * Run: bun run pi-plugin/rlm/test/subagent-bypass.ts
+ *
+ * pi-subagents spawns each child as a standalone pi process (PI_SUBAGENT_CHILD=1)
+ * built around native file tools. RLM must NOT activate in a child — it would
+ * block read/grep with no working repl substitute (the child allowlist has no
+ * repl, and the repo pack may fail in a worktree/temp cwd), leaving the child
+ * unable to read anything. See the guard at the top of src/index.ts.
+ *
+ * This suite drives the real default export with a recording fake pi and asserts:
+ *   - a child bypasses entirely (no hooks / tools / flags registered)
+ *   - the parent keeps full RLM (hooks wired, read/grep blocked, edit/ls allowed)
+ *   - PI_RLM_FORCE_IN_SUBAGENT=1 opts a child back in
+ */
+
+import { check, failureCount } from "./helpers.ts";
+import rlmExtension, { isSubagentChildBypass } from "../src/index.ts";
+
+function setEnv(obj: Record<string, string>) {
+  delete process.env.PI_SUBAGENT_CHILD;
+  delete process.env.PI_RLM_FORCE_IN_SUBAGENT;
+  Object.assign(process.env, obj);
+}
+
+/** A recording fake pi: tracks hook/tool/flag registrations, no-ops everything else. */
+function fakePi() {
+  const tracked = { on: [] as string[], handlers: {} as Record<string, (e: any) => any>, registerTool: [] as string[], registerFlag: [] as string[], registerMessageRenderer: [] as string[] };
+  const pi = new Proxy({}, {
+    get(_t, prop: string) {
+      switch (prop) {
+        case "on": return (e: string, fn: any) => { tracked.on.push(e); tracked.handlers[e] = fn; };
+        case "registerTool": return (t: any) => { tracked.registerTool.push(t?.name); };
+        case "registerFlag": return (n: string) => { tracked.registerFlag.push(n); };
+        case "registerMessageRenderer": return (t: string) => { tracked.registerMessageRenderer.push(t); };
+        default: return () => {};
+      }
+    },
+  });
+  return { pi, tracked };
+}
+
+// ── isSubagentChildBypass() env logic ──
+
+setEnv({ PI_SUBAGENT_CHILD: "1" });
+check("env: child (PI_SUBAGENT_CHILD=1) -> bypass true", isSubagentChildBypass() === true);
+
+setEnv({ PI_SUBAGENT_CHILD: "1", PI_RLM_FORCE_IN_SUBAGENT: "1" });
+check("env: child + force -> bypass false (opt-in honored)", isSubagentChildBypass() === false);
+
+setEnv({});
+check("env: parent (no env) -> bypass false", isSubagentChildBypass() === false);
+
+setEnv({ PI_SUBAGENT_CHILD: "0" });
+check("env: PI_SUBAGENT_CHILD='0' -> bypass false", isSubagentChildBypass() === false);
+
+// ── Case A: child bypasses entirely ──
+
+setEnv({ PI_SUBAGENT_CHILD: "1" });
+const A = fakePi();
+rlmExtension(A.pi);
+check("child: no hooks registered", A.tracked.on.length === 0);
+check("child: no tools registered (repl/rlm absent)", A.tracked.registerTool.length === 0);
+check("child: no --rlm flag", A.tracked.registerFlag.length === 0);
+check("child: no message renderers", A.tracked.registerMessageRenderer.length === 0);
+
+// ── Case B: parent keeps full RLM ──
+
+setEnv({});
+const B = fakePi();
+rlmExtension(B.pi);
+for (const h of ["session_start", "turn_end", "before_agent_start", "context", "tool_call", "tool_result", "session_shutdown"]) {
+  check(`parent: '${h}' hook registered`, B.tracked.on.includes(h));
+}
+check("parent: 'rlm' tool registered", B.tracked.registerTool.includes("rlm"));
+check("parent: '--rlm' flag registered", B.tracked.registerFlag.includes("rlm"));
+check("parent: message renderers registered", B.tracked.registerMessageRenderer.length >= 3);
+
+// tool_call behaviour. enabled defaults to true (mergeConfig({})); invoke synchronously
+// so the async settings-load microtask cannot flip it before the read is evaluated.
+const tc = B.tracked.handlers["tool_call"];
+const block = async (toolName: string, input: Record<string, unknown> = {}) => (await tc({ toolName, input }))?.block === true;
+check("parent: tool_call BLOCKS 'read'", await block("read"));
+check("parent: tool_call BLOCKS 'grep'", await block("grep"));
+check("parent: tool_call does NOT block 'edit'", !(await block("edit")));
+check("parent: tool_call BLOCKS bash reader 'cat'", await block("bash", { command: "cat /etc/hostname" }));
+check("parent: tool_call does NOT block 'bash ls' (capped, not blocked)", !(await block("bash", { command: "ls -la" })));
+
+// ── Case C: force opt-in reactivates RLM in a child ──
+
+setEnv({ PI_SUBAGENT_CHILD: "1", PI_RLM_FORCE_IN_SUBAGENT: "1" });
+const C = fakePi();
+rlmExtension(C.pi);
+check("forced child: 'tool_call' hook registered (RLM active)", C.tracked.on.includes("tool_call"));
+
+const failed = failureCount();
+console.log(`\n${failed === 0 ? "ALL PASS" : `${failed} FAILED`}`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

When RLM mode is enabled, **every pi-subagents child is broken**: the child inherits RLM's `read`/`grep`/bash-reader blocks but has no working `repl` substitute, so it cannot read any file. This PR makes RLM **bypass entirely inside subagent children** (detected via `PI_SUBAGENT_CHILD=1`, which `pi-subagents` already sets on every child). The parent session keeps full RLM.

One-line change at the top of `src/index.ts`:

```ts
export default function rlmExtension(pi: ExtensionAPI): void {
  if (isSubagentChildBypass()) return;   // PI_SUBAGENT_CHILD=1 && PI_RLM_FORCE_IN_SUBAGENT!=1
  // …rest unchanged
}
```

## Root cause — two extensions with opposite, uncoordinated file-access contracts

- **pi-subagents** spawns each child as a standalone `pi` process built around **native** file tools (`read`/`grep`/`bash`) and even force-injects `read` into the child's allowlist (`requireReadTool`, `src/runs/shared/pi-args.ts`). It has **no knowledge** of RLM:
  ```bash
  $ grep -rni 'rlm|\brepl\b|repository context' pi-subagents/src   # → (no output)
  ```
- **@hicaru/pi-rlm**, when enabled, **unconditionally** blocks `read`/`grep` (`BLOCKED_NATIVE_TOOLS`), blocks file-reading bash (`cat`/`sed`/`head`/`grep`/`rg`/…), caps `bash`/`find`/`ls` to ~4 KB, and routes all reading through `repl` — which needs the repo pre-packed via repomix. It makes **no distinction** between the parent and a spawned child:
  ```bash
  $ grep -rni 'PI_SUBAGENT|isChild' @hicaru/pi-rlm/src   # → (no match on the child flag)
  ```
- Children inherit ambient extensions by default (`disableAmbientExtensions = capabilityCeiling?.denyExtensions === true || input.extensions !== undefined`, `pi-args.ts`), so a normal `runs.run({agent, task})` **loads RLM in the child**.

Net effect: in the child, `read` is blocked, `repl` is never injected into the child allowlist, and even an injected `repl` would throw `repository context could not be loaded` because the child cwd is frequently a worktree/temp/non-repo dir. The child is blind.

## The fix

Gate the whole extension on the child flag and `return` before registering any tool/hook/flag:

```ts
const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
const RLM_FORCE_IN_SUBAGENT_ENV = "PI_RLM_FORCE_IN_SUBAGENT";

export function isSubagentChildBypass(): boolean {
  return process.env[SUBAGENT_CHILD_ENV] === "1"
    && process.env[RLM_FORCE_IN_SUBAGENT_ENV] !== "1";
}
```

- Fixes: `read`/`grep` blocked with no substitute; repo-context load failure in child cwds; `context`/`before_agent_start` pollution of the child; `bash`/`find`/`ls` capping in children.
- `PI_RLM_FORCE_IN_SUBAGENT=1` is left as an escape hatch for a future RLM-aware subagents path.
- Side-effect-free: the bypass returns before constructing `SandboxManager` / spawning Python / packing the repo, so children pay zero RLM cost.

### Why not just declare `repl ≡ read` (a shared contract)?

That is the correct **end state**, but the wrong **first step**: `repl` is not a 1:1 substitute (it only reads once the repo is packed, which fails in many child cwds); a capability contract covers tool *availability* but RLM's blocks are *behavioral* (`tool_call` interception); and it needs coordinated releases from two maintainers. This one-sided patch ships now and unblocks the combination immediately.

## Verification

**Live before/after with pi-subagents** (`@hicaru/pi-rlm` 0.2.1, `pi-subagents` 0.43.0), identical agent/model/cwd, RLM enabled via `rlm.json`:

- **Before (patch reverted):** child given `read /tmp/<canary>` returns:
  > The `read` tool was **blocked by RLM mode** — I never obtained the file contents. Attempting the documented workaround (`repl`) is not viable here either: the working directory (`/home/...`) is not a git repository, so `repl` cannot load repository context… I therefore cannot output the canary contents.
- **After (this patch):** same child, same task:
  > The `read` tool worked (not blocked). File contents: `CANARY-9f3a7-rlm-subagent-e2e-…`

**Unit test** — adds `test/subagent-bypass.ts` (bun, same conventions as the existing suite). A node/jiti equivalent with identical assertions passes **24/24**: child registers no hooks/tools/flags; parent wires all hooks and blocks `read`/`grep`/bash-reader `cat` but not `edit`/`ls`; the force opt-in reactivates RLM in a child.

## Files

- `src/index.ts` — the guard (+22).
- `test/subagent-bypass.ts` — new test (+98).
