### PR TITLE
fix(sandbox): worker idle-exit heartbeat + spawn/dispose leak guards

### DIFF
--- a/pi-plugin/rlm/src/sandbox/protocol.ts
+++ b/pi-plugin/rlm/src/sandbox/protocol.ts
@@ -44,7 +44,7 @@ export interface LlmReply {
   readonly error?: string;
 }
 
-export type ParentMessage = WorkerRequest | LlmReply;
+export type ParentMessage = WorkerRequest | LlmReply | Pong;
 
 /** A normal response to a request (keyed by the request `id`). */
 export interface WorkerResponse {
@@ -122,7 +122,21 @@ export type WorkerInterrupt =
   | FinishInterrupt
   | AddContextInterrupt;
 
-export type WorkerMessage = WorkerResponse | WorkerInterrupt;
+/**
+ * Worker idle-heartbeat: sent after `idle_timeout_s` of silence on stdin.
+ * The parent must answer with a `pong` so a live-but-quiet parent keeps the
+ * worker alive; a dead/migrated parent never answers and the worker exits.
+ */
+export interface WorkerHeartbeat {
+  readonly type: "ping";
+}
+
+/** Parent reply to a worker `ping`. */
+export interface Pong {
+  readonly type: "pong";
+}
+
+export type WorkerMessage = WorkerResponse | WorkerInterrupt | WorkerHeartbeat;
 
 export const INTERRUPT_KINDS = Object.freeze(
   new Set<InterruptKind>([
@@ -155,7 +169,12 @@ export function isInterrupt(msg: unknown): msg is WorkerInterrupt {
 }
 
 export function isWorkerMessage(msg: unknown): msg is WorkerMessage {
-  return isWorkerResponse(msg) || isInterrupt(msg);
+  return isWorkerResponse(msg) || isInterrupt(msg) || isHeartbeat(msg);
+}
+
+/** True for the idle-heartbeat `ping` frame (no id/rid, type only). */
+export function isHeartbeat(msg: unknown): msg is WorkerHeartbeat {
+  return isRecord(msg) && msg.type === "ping";
 }
 
 /** Result of a single `repl` block execution, surfaced to the engine/tool. */

--- a/pi-plugin/rlm/src/sandbox/py/worker.py
+++ b/pi-plugin/rlm/src/sandbox/py/worker.py
@@ -25,6 +25,7 @@ import argparse
 import io
 import json
 import os
+import select
 import signal
 import sys
 import time
@@ -824,12 +825,70 @@ class Worker:
         }
 
 
+def _readline_idle(idle_timeout_s: float) -> str | None:
+    """Read one line from the parent, or None after `idle_timeout_s` of silence.
+
+    Uses select() so a silent-but-alive parent does not block forever. None means
+    the idle window elapsed with no input — the caller should ping the parent.
+    On platforms where select() cannot watch stdin (Windows pipes), falls back to
+    a plain blocking readline(), i.e. the pre-watchdog behaviour.
+    """
+    try:
+        readable, _, _ = select.select([_REAL_STDIN], [], [], idle_timeout_s)
+    except (OSError, ValueError):
+        return _REAL_STDIN.readline()
+    if not readable:
+        return None
+    return _REAL_STDIN.readline()
+
+
+def _ping_parent(worker: "Worker", pong_timeout_s: float) -> bool:
+    """Ask the parent for a pong; False when it is gone (exit) and True when alive.
+
+    Sends {"type":"ping"} and waits up to `pong_timeout_s` for a matching pong.
+    Any other frame arriving meanwhile is parked like a mid-exec frame (_pump),
+    so a request racing the heartbeat is not lost. On platforms without select()
+    on stdin, assumes the parent is alive (never probes) — same as pre-watchdog.
+    """
+    _send({"type": "ping"})
+    deadline = time.monotonic() + pong_timeout_s
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        try:
+            readable, _, _ = select.select([_REAL_STDIN], [], [], remaining)
+        except (OSError, ValueError):
+            return True
+        if not readable:
+            return False
+        line = _REAL_STDIN.readline()
+        if not line:
+            return False  # parent closed the pipe
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(msg, dict) and msg.get("type") == "pong":
+            return True
+        if worker.park_reply(msg):
+            continue
+        if isinstance(msg, dict) and "type" in msg:
+            # A request arriving during the heartbeat probe: replay it in main().
+            worker._deferred.append(msg)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--depth", type=int, default=int(os.environ.get("RLM_DEPTH", "1")))
     ap.add_argument("--timeout", type=float, default=float(os.environ.get("RLM_EXEC_TIMEOUT_S", "600")))
     ap.add_argument("--await-timeout", type=float,
                     default=float(os.environ.get("RLM_AWAIT_TIMEOUT_S", "600")))
+    ap.add_argument("--idle-timeout", type=float,
+                    default=float(os.environ.get("RLM_IDLE_TIMEOUT_S", "600")))
     ap.add_argument("--max-prompt-chars", type=int,
                     default=int(os.environ.get("RLM_MAX_PROMPT_CHARS", "400000")))
     args = ap.parse_args()
@@ -839,11 +898,23 @@ def main() -> None:
                     await_timeout_s=args.await_timeout)
     _send({"id": "_init", "ok": True})
 
+    # Idle watchdog: if the parent has been silent for idle_timeout_s, ping it.
+    # A live parent answers with a pong; a dead/migrated parent does not, and the
+    # worker exits instead of lingering forever as a zombie (stdin pipe writable
+    # end can be inherited by unrelated processes, so EOF is not a reliable exit).
+    idle_timeout_s = args.idle_timeout
+    pong_timeout_s = 5.0
+
     while True:
         # Requests that arrived mid-exec were parked by _pump; replay them before reading.
         req = worker.take_deferred()
         if req is None:
-            line = _REAL_STDIN.readline()
+            line = _readline_idle(idle_timeout_s)
+            if line is None:
+                # Idle timeout — probe the parent. Exit only if it is truly gone.
+                if not _ping_parent(worker, pong_timeout_s):
+                    return
+                continue
             if not line:
                 return
             raw = line.strip()

--- a/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
+++ b/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
@@ -21,6 +21,8 @@ export interface SandboxManagerConfig {
   readonly maxPromptChars: number;
   /** Max seconds the worker waits for a host reply while parked in await_task. */
   readonly awaitTimeoutS: number;
+  /** Max seconds the worker idles before it pings the parent for liveness. */
+  readonly idleTimeoutS?: number;
   readonly signal?: AbortSignal;
   readonly onSandboxDiscarded?: () => void;
 }
@@ -29,6 +31,11 @@ export class SandboxManager {
   private sandbox: PythonSandbox | null = null;
   private disposed = false;
   private initPromise: Promise<PythonSandbox> | null = null;
+  /**
+   * Aborts an in-flight spawn when dispose() races it — the spawned child is SIGKILLed
+   * via the sandbox's own signal wiring instead of leaking unattached.
+   */
+  private spawnAbort: AbortController | null = null;
   /** Serialized execution queue — concurrent repl() calls wait for predecessor. */
   private execQueue: Promise<void> = Promise.resolve();
   private pendingExecCount = 0;
@@ -96,27 +103,49 @@ export class SandboxManager {
 
     if (this.initPromise) return this.initPromise;
 
+    // Bug-fix: a dispose() racing the spawn must abort it. The spawned child is SIGKILLed
+    // via the sandbox's signal wiring instead of leaking as an unattached orphan.
+    const spawnAbort = new AbortController();
+    this.spawnAbort = spawnAbort;
+
     this.initPromise = PythonSandbox.spawn({
       execTimeoutS: this.config.execTimeoutS,
       requestTimeoutMs: this.config.requestTimeoutMs,
       python: this.config.python,
-      signal: this.config.signal,
+      signal: combineAbortSignals(this.config.signal, spawnAbort.signal),
       initTimeoutMs: this.config.sandboxInitTimeoutMs,
       maxPromptChars: this.config.maxPromptChars,
       awaitTimeoutS: this.config.awaitTimeoutS,
+      idleTimeoutS: this.config.idleTimeoutS,
       handlers,
     }).then(async (s) => {
-      // Load context on first creation if available (empty list is a valid starting value).
-      if (this.contextPayload !== undefined) {
-        await s.loadContext(this.contextPayload);
-        this.contextLoaded = true;
+      // Bug-fix: dispose() may have raced the spawn. The child was SIGKILLed via
+      // spawnAbort, but dispose it explicitly too so no resource outlives the manager.
+      if (this.disposed) {
+        await s.dispose().catch(() => {});
+        throw new Error("SandboxManager disposed during spawn");
+      }
+
+      try {
+        // Load context on first creation if available (empty list is a valid starting value).
+        if (this.contextPayload !== undefined) {
+          await s.loadContext(this.contextPayload);
+          this.contextLoaded = true;
+        }
+      } catch (err) {
+        // Bug-fix: loadContext failed after spawn — dispose the child instead of
+        // leaking it (the .catch below only resets initPromise and can't reach `s`).
+        await s.dispose().catch(() => {});
+        throw err;
       }
       this.sandbox = s;
       this.initPromise = null;
+      this.spawnAbort = null;
       return s;
     }).catch((err) => {
       this.contextLoaded = false;
       this.initPromise = null;
+      this.spawnAbort = null;
       throw err;
     });
 
@@ -196,6 +225,9 @@ export class SandboxManager {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    // Abort an in-flight spawn: the child is SIGKILLed and the .then guard above throws,
+    // so a dispose racing getOrCreate can never leave an unattached sandbox behind.
+    this.spawnAbort?.abort();
     await this.sandbox?.dispose();
     if (this.sandbox !== null) {
       this.sandbox = null;
@@ -203,4 +235,23 @@ export class SandboxManager {
       this.config.onSandboxDiscarded?.();
     }
   }
+}
+
+/**
+ * Combine AbortSignals so aborting any of them aborts the result.
+ * Returns undefined when there is nothing to combine (spawn without a signal).
+ */
+function combineAbortSignals(...signals: (AbortSignal | undefined)[]): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => s !== undefined);
+  if (present.length === 0) return undefined;
+  if (present.length === 1) return present[0];
+  const combined = new AbortController();
+  for (const s of present) {
+    if (s.aborted) {
+      combined.abort();
+      break;
+    }
+    s.addEventListener("abort", () => combined.abort(), { once: true });
+  }
+  return combined.signal;
 }

--- a/pi-plugin/rlm/src/sandbox/sandbox.ts
+++ b/pi-plugin/rlm/src/sandbox/sandbox.ts
@@ -12,6 +12,7 @@ import { once } from "node:events";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  isHeartbeat,
   isInterrupt,
   isWorkerMessage,
   type ParentMessage,
@@ -48,6 +49,12 @@ export interface SandboxOptions {
    * (await_task / sync sub-call). Defaults to the worker's own RLM_AWAIT_TIMEOUT_S (600).
    */
   readonly awaitTimeoutS?: number;
+  /**
+   * Max seconds the worker idles before it pings the parent for liveness. A parent that
+   * never answers (dead/migrated) lets the worker exit instead of lingering as a zombie.
+   * Defaults to the worker's own RLM_IDLE_TIMEOUT_S (600).
+   */
+  readonly idleTimeoutS?: number;
 }
 
 const WORKER_PATH = join(dirname(fileURLToPath(import.meta.url)), "py", "worker.py");
@@ -125,6 +132,9 @@ export class PythonSandbox {
     }
     if (opts.awaitTimeoutS !== undefined) {
       workerArgs.push("--await-timeout", String(opts.awaitTimeoutS));
+    }
+    if (opts.idleTimeoutS !== undefined) {
+      workerArgs.push("--idle-timeout", String(opts.idleTimeoutS));
     }
     this.proc = spawn(
       python,
@@ -404,9 +414,16 @@ export class PythonSandbox {
           detached: msg.detached === true,
           prompts: "prompts" in msg ? msg.prompts?.length : 1,
         });
+      } else if (isHeartbeat(msg)) {
+        trace("frame.in", { frame: "ping" });
       } else {
         trace("frame.in", { frame: "response", id: msg.id, ok: msg.ok });
       }
+    }
+    if (isHeartbeat(msg)) {
+      // Idle probe from the worker — answer so a live parent keeps it alive.
+      this.send({ type: "pong" });
+      return;
     }
     if (isInterrupt(msg)) {
       this.touchPending();

--- a/pi-plugin/rlm/test/smoke.ts
+++ b/pi-plugin/rlm/test/smoke.ts
@@ -21,6 +21,7 @@ const SUITES: readonly string[] = Object.freeze([
   "phase-always-spawn.ts",
   "phase-encoding.ts", "phase-retrieval.ts", "phase-llm-model.ts",
   "native-mode.ts", "native-smoke.ts", "subagent-bypass.ts",
+  "worker-lifecycle.ts",
 ]);
 
 async function assertEditSurfaceRemoved(): Promise<void> {

--- a/pi-plugin/rlm/test/worker-lifecycle.ts
+++ b/pi-plugin/rlm/test/worker-lifecycle.ts
@@ -1,0 +1,192 @@
+/**
+ * Worker-lifecycle regression tests.
+ * Run: bun run pi-plugin/rlm/test/worker-lifecycle.ts
+ *
+ * Covers three upstream worker bugs:
+ *   ① idle exit — a worker whose parent stops answering (crash / migration) must
+ *     exit instead of lingering forever on a blocking readline();
+ *   ②A dispose-on-loadContext-failure — a sandbox spawned but failing context load
+ *     must be disposed, not leaked;
+ *   ②B dispose racing spawn — disposing a SandboxManager mid-spawn must abort the
+ *     child and leave nothing behind.
+ */
+
+import { once } from "node:events";
+import { execSync, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { check, failureCount } from "./helpers.ts";
+import { PythonSandbox } from "../src/sandbox/sandbox.ts";
+import { SandboxManager } from "../src/sandbox/sandbox-manager.ts";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const WORKER_PATH = join(TEST_DIR, "..", "src", "sandbox", "py", "worker.py");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Count live `worker.py` processes (the `[w]` trick excludes the grep itself). */
+function countWorkerProcs(): number {
+  try {
+    const out = execSync("ps -eo command | grep -c '[w]orker.py' || true", { stdio: ["ignore", "pipe", "ignore"] });
+    return Number.parseInt(out.toString().trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function spawnRawWorker(idleTimeoutS: number) {
+  return spawn("python3", [WORKER_PATH, "--depth", "1", "--idle-timeout", String(idleTimeoutS)], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+/** Read the next JSONL line from a stream. */
+function nextLine(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: stream });
+    rl.once("line", (line) => { rl.close(); resolve(line); });
+  });
+}
+
+// ── Bug ①: idle exit ──
+
+async function testIdleExitWhenParentSilent() {
+  // A parent that never answers the ping (crashed / migrated) must not pin the worker.
+  const worker = spawnRawWorker(1);
+  await nextLine(worker.stdout); // {"id":"_init","ok":true}
+  // Do NOT answer the ping. Worker should exit ~idle(1s) + pong-wait(5s) after _init.
+  const exited = await Promise.race([
+    once(worker, "exit").then(() => true),
+    sleep(20_000).then(() => { worker.kill("SIGKILL"); return false; }),
+  ]);
+  check("① idle exit — worker exits when parent stays silent", exited);
+}
+
+async function testIdleKeepsAliveWhenParentAnswers() {
+  // A live parent answers pongs, so the worker stays up across idle windows.
+  const worker = spawnRawWorker(1);
+  const rl = createInterface({ input: worker.stdout });
+  rl.on("line", (line) => {
+    try {
+      const msg = JSON.parse(line) as { type?: string };
+      if (msg.type === "ping") worker.stdin.write('{"type":"pong"}\n');
+    } catch { /* non-JSON breadcrumb, ignore */ }
+  });
+  await nextLine(worker.stdout); // _init
+  await sleep(3_000); // longer than the 1s idle window + ping cadence
+  const alive = worker.exitCode === null && worker.signalCode === null;
+  check("① idle keep-alive — worker stays alive while parent answers pongs", alive);
+  worker.stdin.write('{"id":"s","type":"shutdown"}\n');
+  await once(worker, "exit").catch(() => {});
+  rl.close();
+}
+
+// ── Bug ②A: loadContext failure must dispose the spawned sandbox ──
+
+async function testLoadContextFailureDisposes() {
+  // Unit-level: stub PythonSandbox.spawn so the spawn succeeds but loadContext throws;
+  // the manager must dispose the child. (A real worker's load_context is fast and reliable,
+  // so an integration version would need a brittle watchdog race to trigger the failure.)
+  const realSpawn = PythonSandbox.spawn;
+  let disposed = false;
+  const fakeSandbox = {
+    dispose: async () => { disposed = true; },
+    loadContext: async () => { throw new Error("context load failed"); },
+  } as unknown as PythonSandbox;
+  PythonSandbox.spawn = async () => fakeSandbox;
+  try {
+    const mgr = new SandboxManager({
+      execTimeoutS: 30,
+      requestTimeoutMs: 10_000,
+      python: "python3",
+      sandboxInitTimeoutMs: 30_000,
+      maxPromptChars: 400_000,
+      awaitTimeoutS: 10,
+    });
+    mgr.contextPayload = [{ path: "x.ts", content: "x", tokens: 1 }];
+    let rejected = false;
+    try {
+      await mgr.getOrCreate({});
+    } catch {
+      rejected = true;
+    }
+    check("②A — getOrCreate rejects when loadContext fails", rejected);
+    check("②A — spawned sandbox is disposed on loadContext failure", disposed);
+    check("②A — manager holds no sandbox after failure", !mgr.isAlive);
+    await mgr.dispose();
+  } finally {
+    PythonSandbox.spawn = realSpawn;
+  }
+}
+
+// ── Bug ②B: dispose racing spawn must leave nothing behind ──
+
+async function testDisposeRacingSpawn() {
+  // Deterministic unit check: a spawn that resolves AFTER dispose must not attach
+  // the sandbox to the manager (the .then guard disposes it instead). Stub spawn
+  // with an already-resolved promise so the guard is the only thing between the
+  // resolved child and the disposed manager.
+  const realSpawn = PythonSandbox.spawn;
+  let disposed = false;
+  const fakeSandbox = {
+    dispose: async () => { disposed = true; },
+    // Successful loadContext — so the ②A catch path is NOT what disposes the child
+    // here; only the ②B disposed guard can. Without it the sandbox attaches to the
+    // manager and this test fails (manager holds a sandbox after dispose).
+    loadContext: async () => 0,
+  } as unknown as PythonSandbox;
+  PythonSandbox.spawn = async () => fakeSandbox;
+  try {
+    const mgr = new SandboxManager({
+      execTimeoutS: 30,
+      requestTimeoutMs: 10_000,
+      python: "python3",
+      sandboxInitTimeoutMs: 30_000,
+      maxPromptChars: 400_000,
+      awaitTimeoutS: 10,
+    });
+    const spawning = mgr.getOrCreate({});
+    await mgr.dispose();
+    await spawning.catch(() => {});
+    check("②B — manager holds no sandbox when dispose wins the race", !mgr.isAlive);
+    check("②B — racing child is disposed, not leaked", disposed);
+  } finally {
+    PythonSandbox.spawn = realSpawn;
+  }
+
+  // Integration: real spawn + immediate dispose — abort SIGKILLs the child and no
+  // worker process outlives the manager.
+  const before = countWorkerProcs();
+  const mgr2 = new SandboxManager({
+    execTimeoutS: 30,
+    requestTimeoutMs: 10_000,
+    python: "python3",
+    sandboxInitTimeoutMs: 30_000,
+    maxPromptChars: 400_000,
+    awaitTimeoutS: 10,
+  });
+  const spawning2 = mgr2.getOrCreate({});
+  await mgr2.dispose();
+  await spawning2.catch(() => {});
+  await sleep(500);
+  check("②B — integration: no worker process after racing dispose",
+    countWorkerProcs() <= before, `before=${before}`);
+}
+
+// ── Main ──
+
+async function main() {
+  console.log("─── worker-lifecycle ───");
+  await testIdleExitWhenParentSilent();
+  await testIdleKeepsAliveWhenParentAnswers();
+  await testLoadContextFailureDisposes();
+  await testDisposeRacingSpawn();
+
+  console.log(`\n${failureCount() === 0 ? "✓ All tests passed" : `✗ ${failureCount()} failure(s)`}`);
+  process.exit(failureCount() > 0 ? 1 : 0);
+}
+
+await main();


### PR DESCRIPTION
# PR: fix worker lifecycle — idle exit heartbeat + spawn/dispose leak guards

**Target repo**: `openzebra/rlm.pi` · `pi-plugin/rlm`
**Base**: `master` (upstream 0.3.2, 8f2094c)
**源**: 上游 master 0.3.2 快照上的单点修复（vendor 与 node_modules 同步）

## Summary

Fixes three worker-lifecycle bugs found by source-level audit of 0.3.2:

**① Worker never exits when its parent dies/migrates.** `worker.py`'s main loop blocked
forever on `_REAL_STDIN.readline()`; exit relied solely on a parent `shutdown` frame or
stdin EOF. The writable end of the stdin pipe can be inherited by unrelated processes, so
EOF is not a reliable exit — a crashed/upgraded parent left orphan workers running for
days (observed: PID hanging 40h+ at ~14s CPU).

Fix: an idle watchdog. After `idle_timeout_s` (default 600, `RLM_IDLE_TIMEOUT_S`) of
silence the worker sends `{"type":"ping"}`; a live parent answers `{"type":"pong"}`
(sandbox.ts dispatch), a dead one does not, and the worker exits. Long-thinking sessions
are unaffected — a ponged worker keeps waiting.

**②A Spawned sandbox leaked when `loadContext` failed.** `SandboxManager.getOrCreate`
caught load failures in a `.catch` that only reset `initPromise`; the spawned child was
unreachable there (scoped to the `.then`) and leaked. The load is now wrapped so the child
is `dispose()`d before rethrowing.

**②B Disposing mid-spawn leaked the new sandbox.** `dispose()` only handled
`this.sandbox`, which is still null while spawn is in flight; the `.then` attached the
finished sandbox with no `disposed` check, and nobody ever disposed it. Fix: an internal
AbortController combined with the config signal SIGKILLs the in-flight child, and the
`.then` disposes + throws if the manager was disposed meanwhile.

## Changes

| File | Change |
|---|---|
| `src/sandbox/py/worker.py` | idle watchdog: `select()`-based `_readline_idle`, `_ping_parent` heartbeat, `--idle-timeout` arg (env `RLM_IDLE_TIMEOUT_S`, default 600); Windows fallback keeps pre-watchdog blocking read |
| `src/sandbox/protocol.ts` | `ping`/`pong` frame types; `isHeartbeat`; `ParentMessage`/`WorkerMessage` extended |
| `src/sandbox/sandbox.ts` | dispatch answers `ping` with `pong`; `SandboxOptions.idleTimeoutS` → `--idle-timeout` |
| `src/sandbox/sandbox-manager.ts` | ②A load-failure dispose; ②B spawn abort + disposed guard; `SandboxManagerConfig.idleTimeoutS` |
| `test/worker-lifecycle.ts` | new regression suite: idle exit (silent parent), keep-alive (pong), ②A dispose-on-load-failure, ②B dispose-racing-spawn (stub + integration) |
| `test/smoke.ts` | register `worker-lifecycle.ts` |

## Verification

- New `worker-lifecycle.ts` suite — 8 checks, all green:
  - raw worker with `--idle-timeout 1`, parent never answers → process exits (~6s)
  - same, parent answers pongs → stays alive across idle windows, clean shutdown
  - ②A: spawn stub whose `loadContext` throws → child `dispose()` called, manager empty
  - ②B: spawn stub resolving after `dispose()` → child disposed, manager empty; real
    spawn + immediate dispose → no `worker.py` process left behind
- Each regression test proven effective by reverting the corresponding fix and watching
  the check fail (②A dispose assertion; ②B disposed-child assertion).
- Full suite: `bun run test` — all phase suites + smoke pass.
- `tsc --noEmit` clean.

## Testing notes for reviewers

- No protocol break: `ping`/`pong` are additive frame types; an old parent that ignores
  `ping` simply lets the worker exit after the pong wait — exactly the zombie cleanup
  this PR wants.
- Defaults unchanged for existing users: idle watchdog is 600s and only pings a live
  parent, so no session is torn down while the host is healthy.
