### PR TITLE
fix(rlm): atomic writes + model pin persistence (v0.3.2)

### DIFF
--- a/pi-plugin/rlm/CHANGELOG.md
+++ b/pi-plugin/rlm/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Atomic writes for rlm.json.** Settings are now written to a `.tmp` file then renamed —
+  if Pi crashes mid-write, the previous config survives instead of being truncated.
+- **Immediate model-choice persistence.** When you pick a sub-LLM model in
+  `/rlm-config`, the choice is saved to disk BEFORE the config panel opens — if the
+  panel fails or Pi exits before you close it, the model pin survives.
+- **Model picker no longer defaults to "cheapest" when the pinned model is absent.**
+  If your saved model is temporarily unavailable (e.g. API key not loaded yet),
+  the picker pre-selects the first real model instead of "cheapest auto" —
+  accidental Enter won't wipe the pin.
 - **Thinking/CoT guidance in native prompt.** A `THINKING RULE` section tells the model
   when to plan out loud (complex decomposition, uncertainty) vs. jump to `repl()` (simple
   lookups, known paths). Prevents premature repl() calls on uncertain targets.

--- a/pi-plugin/rlm/src/commands/rlm-config.ts
+++ b/pi-plugin/rlm/src/commands/rlm-config.ts
@@ -68,6 +68,13 @@ export async function runRlmConfig(controller: RlmController, ctx: ExtensionCont
   // Choosing cheapest must NOT wipe subSampling.reasoning (null !== undefined used to).
   applyLlmSelection(controller, llm);
 
+  // Persist model choice immediately — if showConfigPanel throws or process exits before it
+  // returns, the pin survives (Root Cause #2, v0.3.2).
+  if (llm !== undefined) {
+    const saved = await controller.persist();
+    if (!saved) ctx.ui.notify("RLM: failed to save llm setting", "error");
+  }
+
   controller.setConfig(await showConfigPanel(ctx, controller.config));
 
   const persisted = await controller.persist();

--- a/pi-plugin/rlm/src/config/settings.ts
+++ b/pi-plugin/rlm/src/config/settings.ts
@@ -1,6 +1,6 @@
 /** Persist RLM settings (tunable config + pinned sub-LLM model id). */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir, type ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
@@ -132,8 +132,10 @@ export async function loadSettings(): Promise<PersistedSettings> {
 export async function saveSettings(s: PersistedSettings): Promise<boolean> {
   try {
     const p = settingsPath();
+    const tmp = `${p}.tmp`;
     await mkdir(dirname(p), { recursive: true });
-    await writeFile(p, `${JSON.stringify(s, null, 2)}\n`);
+    await writeFile(tmp, `${JSON.stringify(s, null, 2)}\n`);
+    await rename(tmp, p);
     return true;
   } catch {
     return false;

--- a/pi-plugin/rlm/src/ui/model-picker.ts
+++ b/pi-plugin/rlm/src/ui/model-picker.ts
@@ -68,7 +68,11 @@ export function initialModelPickerIndex(
   const ref = current ? `${current.provider}/${current.id}` : currentRef;
   if (!ref) return 0;
   const idx = models.findIndex((m) => `${m.provider}/${m.id}` === ref);
-  if (idx < 0) return 0;
+  // When a saved ref exists but the model is absent from the current catalog
+  // (e.g. provider not refreshed yet), pre-select the first real model — NOT
+  // "cheapest auto". Accidentally hitting Enter on cheapest would wipe the pin
+  // silently (Root Cause #4, v0.3.2).
+  if (idx < 0) return ref ? offset : 0;
   return idx + offset;
 }
 


### PR DESCRIPTION
Three root-cause fixes for LLM model dropping to cheapest:

* Atomic writes: rlm.json written to .tmp then rename() — crash mid-write no longer corrupts the config (Root Cause #1)
* Immediate model-choice persist: llm pin saved BEFORE config panel opens, so a crash or panel failure can't lose the choice (Root Cause #2)
* Model picker: when the pinned model is temporarily unavailable, pre-select the first real model instead of 'cheapest auto' — accidental Enter won't silently wipe the pin (Root Cause #4)

Root Cause #3 (session_start refresh race) is self-healing via lazy resolveModels() in start() — no code change needed.