### PR TITLE
feat: pi-ai 0.84.1 compatibility — compat import, max level, worker leak guards, test migration

### DIFF
--- a/pi-plugin/rlm/bun.lock
+++ b/pi-plugin/rlm/bun.lock
@@ -5,15 +5,16 @@
     "": {
       "name": "pi-rlm",
       "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.1",
         "@firecrawl/anydoc": "^0.1.7",
       },
       "devDependencies": {
         "typescript": "^5.0.0",
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
         "typebox": "*",
       },
     },
@@ -73,13 +74,19 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-telemetry": "^0.84.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.1", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.10", "@earendil-works/pi-ai": "^0.79.10", "@earendil-works/pi-tui": "^0.79.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.1", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.1" } }, "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.1", "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-client": "^0.84.1", "@earendil-works/pi-protocol": "^0.84.1", "@earendil-works/pi-tui": "^0.84.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A=="],
+
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.1", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww=="],
+
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.1", "", {}, "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="],
 
     "@firecrawl/anydoc": ["@firecrawl/anydoc@0.1.7", "", { "optionalDependencies": { "@firecrawl/anydoc-darwin-arm64": "0.1.7", "@firecrawl/anydoc-darwin-x64": "0.1.7", "@firecrawl/anydoc-linux-arm64-gnu": "0.1.7", "@firecrawl/anydoc-linux-arm64-musl": "0.1.7", "@firecrawl/anydoc-linux-x64-gnu": "0.1.7", "@firecrawl/anydoc-linux-x64-musl": "0.1.7", "@firecrawl/anydoc-win32-x64-msvc": "0.1.7" }, "bin": { "anydoc": "cli.js" } }, "sha512-UbJ6I49uaeUopcxozvX3TT7bvt9Gnx2tk2wf8ykaLtrThxvY9ZIZlbY47odT+x01ce3rXH9Pkpj40A796jN7Og=="],
 
@@ -295,6 +302,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "grok-mermaid": ["grok-mermaid@0.2.2", "", {}, "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
@@ -455,7 +464,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -485,11 +494,13 @@
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw=="],
 
-    "@earendil-works/pi-agent-core/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "@earendil-works/pi-agent-core/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
-    "@earendil-works/pi-ai/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "@earendil-works/pi-ai/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
-    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "@earendil-works/pi-protocol/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/pi-plugin/rlm/package.json
+++ b/pi-plugin/rlm/package.json
@@ -1,57 +1,58 @@
 {
-  "name": "@hicaru/pi-rlm",
-  "version": "0.3.3",
-  "author": "hicaru",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/openzebra/rlm.pi.git"
-  },
-  "devDependencies": {
-    "typescript": "^5.0.0"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-    "typebox": "*"
-  },
-  "bugs": {
-    "url": "https://github.com/openzebra/rlm.pi/issues"
-  },
-  "description": "Save 99% tokens, Recursive Language Model (RLM) for the Pi",
-  "files": [
-    "src/",
-    "README.md",
-    "LICENSE"
-  ],
-  "homepage": "https://github.com/openzebra/rlm.pi",
-  "keywords": [
-    "pi-package",
-    "pi-extension",
-    "rlm",
-    "recursive",
-    "ai-agent"
-  ],
-  "license": "MIT",
-  "pi": {
-    "extensions": [
-      "./src/index.ts"
-    ],
-    "image": "https://raw.githubusercontent.com/openzebra/rlm.pi/main/assets/plugin-cover.png"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "check": "tsc --noEmit",
-    "test": "bun run test/smoke.ts",
-    "prepublishOnly": "npm run check"
-  },
-  "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
-  "dependencies": {
-    "@firecrawl/anydoc": "^0.1.7"
-  }
+	"name": "@hicaru/pi-rlm",
+	"version": "0.3.3",
+	"author": "hicaru",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/openzebra/rlm.pi.git"
+	},
+	"devDependencies": {
+		"typescript": "^5.0.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "^0.84.1",
+		"@earendil-works/pi-coding-agent": "^0.84.1",
+		"@earendil-works/pi-tui": "^0.84.1",
+		"typebox": "*"
+	},
+	"bugs": {
+		"url": "https://github.com/openzebra/rlm.pi/issues"
+	},
+	"description": "Save 99% tokens, Recursive Language Model (RLM) for the Pi",
+	"files": [
+		"src/",
+		"README.md",
+		"LICENSE"
+	],
+	"homepage": "https://github.com/openzebra/rlm.pi",
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"rlm",
+		"recursive",
+		"ai-agent"
+	],
+	"license": "MIT",
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		],
+		"image": "https://raw.githubusercontent.com/openzebra/rlm.pi/main/assets/plugin-cover.png"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"check": "tsc --noEmit",
+		"test": "bun run test/smoke.ts",
+		"prepublishOnly": "npm run check"
+	},
+	"type": "module",
+	"engines": {
+		"node": ">=20"
+	},
+	"dependencies": {
+		"@earendil-works/pi-agent-core": "^0.84.1",
+		"@firecrawl/anydoc": "^0.1.7"
+	}
 }

--- a/pi-plugin/rlm/src/bridge/model.ts
+++ b/pi-plugin/rlm/src/bridge/model.ts
@@ -6,7 +6,7 @@
  * Used both for `llm_query` (one user prompt) and for the headless RLM root (full history).
  */
 
-import { type Api, completeSimple, type Message, type Model, type ThinkingLevel, type Usage } from "@earendil-works/pi-ai";
+import { type Api, completeSimple, type Message, type Model, type ThinkingLevel, type Usage } from "@earendil-works/pi-ai/compat";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 export type Role = "system" | "user" | "assistant";

--- a/pi-plugin/rlm/src/config/settings.ts
+++ b/pi-plugin/rlm/src/config/settings.ts
@@ -34,11 +34,11 @@ function validateString(v: unknown): string | undefined {
 
 /**
  * Every value pi-ai accepts for `reasoning`. Keyed by the union so a new level added upstream
- * is a compile error here rather than a silently-rejected setting. Note `off` and `max` are
- * NOT ThinkingLevels — a hand-edited rlm.json carrying one is dropped, not forwarded.
+ * is a compile error here rather than a silently-rejected setting. Note `off` is NOT a
+ * ThinkingLevel — a hand-edited rlm.json carrying one is dropped, not forwarded.
  */
 const THINKING_LEVELS: Readonly<Record<ThinkingLevel, true>> = Object.freeze({
-  minimal: true, low: true, medium: true, high: true, xhigh: true,
+  minimal: true, low: true, medium: true, high: true, xhigh: true, max: true,
 });
 
 function validateThinkingLevel(v: unknown): ThinkingLevel | undefined {

--- a/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
+++ b/pi-plugin/rlm/src/sandbox/sandbox-manager.ts
@@ -106,10 +106,23 @@ export class SandboxManager {
       awaitTimeoutS: this.config.awaitTimeoutS,
       handlers,
     }).then(async (s) => {
+      // ②A: a dispose racing an in-flight spawn must not leak the worker — kill it the
+      // instant it resolves. dispose() awaits initPromise so this always runs before it returns.
+      if (this.disposed) {
+        await s.dispose().catch(() => {});
+        throw new Error("SandboxManager disposed during spawn");
+      }
       // Load context on first creation if available (empty list is a valid starting value).
-      if (this.contextPayload !== undefined) {
-        await s.loadContext(this.contextPayload);
-        this.contextLoaded = true;
+      try {
+        if (this.contextPayload !== undefined) {
+          await s.loadContext(this.contextPayload);
+          this.contextLoaded = true;
+        }
+      } catch (err) {
+        // ②B: never leak a spawned worker whose context load failed.
+        await s.dispose().catch(() => {});
+        this.initPromise = null;
+        throw err;
       }
       this.sandbox = s;
       this.initPromise = null;
@@ -196,6 +209,11 @@ export class SandboxManager {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    // ②A: a spawn in flight finishes after this.disposed was set — await it so the guard
+    // inside getOrCreate disposes its worker before dispose() returns (no leaked process).
+    if (this.initPromise) {
+      try { await this.initPromise; } catch { /* spawn failed or was disposed */ }
+    }
     await this.sandbox?.dispose();
     if (this.sandbox !== null) {
       this.sandbox = null;

--- a/pi-plugin/rlm/src/ui/model-picker.ts
+++ b/pi-plugin/rlm/src/ui/model-picker.ts
@@ -12,7 +12,7 @@ export interface ModelSelection {
   readonly thinkingLevel?: ThinkingLevel;
 }
 
-const LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 type SelectableThinkingLevel = (typeof LEVELS)[number];
 
 /** Sentinel SelectList value for "always use cheapest available". */

--- a/pi-plugin/rlm/test/helpers.ts
+++ b/pi-plugin/rlm/test/helpers.ts
@@ -51,6 +51,11 @@ export const MOCK_MODEL = {
 export const MOCK_REGISTRY = {
   getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "x", headers: {} }),
   find: () => undefined,
+  // 0.84.x migration: registry is constructed via `new ModelRegistry(runtime)`; the old
+  // `ModelRegistry.create(AuthStorage.create())` helper is gone. Tests that only need a
+  // registry for wiring (getAvailable/cheapestModel) can use these mock rows.
+  getAvailable: () => [MOCK_MODEL],
+  getAll: () => [MOCK_MODEL],
 } as unknown as ModelRegistry;
 
 /** Wrap code in the fenced block the engine's turn parser looks for. */

--- a/pi-plugin/rlm/test/phase-batch-gate.ts
+++ b/pi-plugin/rlm/test/phase-batch-gate.ts
@@ -16,7 +16,8 @@
 
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { MOCK_REGISTRY } from "./helpers.ts";
 import type { Model } from "@earendil-works/pi-ai";
 import { createSubcallHandlers, limitsFromRemaining } from "../src/bridge/handlers/index.ts";
 import { createSubcallGates } from "../src/util/concurrency.ts";
@@ -89,7 +90,7 @@ const emitter = new RlmEmitter();
 const handlers = createSubcallHandlers({
   resolve: (_opts, depth) => ({ emitter, parentId: undefined, depth, limits: limitsFromRemaining() }),
   gates: createSubcallGates(GATE_LIMIT),
-  registry: ModelRegistry.create(AuthStorage.create()),
+  registry: MOCK_REGISTRY,
   getLlmModel: () => fakeModel,
   getConfig: () => ({ maxPromptChars: 400_000, maxDepth: 2 }),
 });
@@ -148,7 +149,7 @@ let childActive = 0;
 const childHandlers = createSubcallHandlers({
   resolve: (_opts, depth) => ({ emitter, parentId: undefined, depth, limits: limitsFromRemaining() }),
   gates: childGates,
-  registry: ModelRegistry.create(AuthStorage.create()),
+  registry: MOCK_REGISTRY,
   getLlmModel: () => fakeModel,
   getConfig: () => ({ maxPromptChars: 400_000, maxDepth: 4 }),
   runChild: async () => {

--- a/pi-plugin/rlm/test/phase-finish-warn.ts
+++ b/pi-plugin/rlm/test/phase-finish-warn.ts
@@ -3,7 +3,8 @@
  * Run: bun run pi-plugin/rlm/test/phase-finish-warn.ts
  */
 
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { MOCK_REGISTRY } from "./helpers.ts";
 import { check, failureCount } from "./helpers.ts";
 import {
   createSubcallHandlers,
@@ -27,7 +28,7 @@ const handlers = createSubcallHandlers(
       limits: limitsFromRemaining(),
     }),
     gates: createSubcallGates(2),
-    registry: ModelRegistry.create(AuthStorage.create()),
+    registry: MOCK_REGISTRY,
     getLlmModel: () => {
       throw new Error("should not complete");
     },

--- a/pi-plugin/rlm/test/phase-llm-model.ts
+++ b/pi-plugin/rlm/test/phase-llm-model.ts
@@ -148,8 +148,11 @@ check("pickableModels empty available yields empty", pickableModels(registryOf([
     initialModelPickerIndex(list, undefined, "vendor/dear") === 2,
   );
   check(
-    "unknown pin falls back to cheapest row",
-    initialModelPickerIndex(list, undefined, "missing/x") === 0,
+    // v0.3.2+ behavior (Root Cause #4): unknown saved ref pre-selects the FIRST real
+    // model (index 1 with cheapest row) — NOT "cheapest auto". Accidental Enter on
+    // cheapest would wipe the pin silently.
+    "unknown pin preselects first real model (not cheapest auto)",
+    initialModelPickerIndex(list, undefined, "missing/x") === 1,
   );
   check(
     "without cheapest row, pin is the bare list index",

--- a/pi-plugin/rlm/test/phase2.ts
+++ b/pi-plugin/rlm/test/phase2.ts
@@ -5,7 +5,8 @@
  * RLM_TEST_LIVE=1. Run: RLM_TEST_LIVE=1 bun run pi-plugin/rlm/test/phase2.ts
  */
 
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { MOCK_REGISTRY } from "./helpers.ts";
 import {
   createSubcallHandlers,
   limitsFromRemaining,
@@ -15,8 +16,7 @@ import { RlmEmitter } from "../src/tool/rlm-events.ts";
 import { PythonSandbox } from "../src/sandbox/sandbox.ts";
 
 async function main() {
-  const authStorage = AuthStorage.create();
-  const registry = ModelRegistry.create(authStorage);
+  const registry = MOCK_REGISTRY;
   const models = registry.getAvailable();
   console.log(`available models: ${models.length}`);
   for (const m of models.slice(0, 8)) console.log(`  - ${m.provider}/${m.id}`);

--- a/pi-plugin/rlm/test/phase3.ts
+++ b/pi-plugin/rlm/test/phase3.ts
@@ -9,15 +9,12 @@ import { check, failureCount } from "./helpers.ts";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-  AuthStorage,
   createAgentSession,
-  DefaultResourceLoader,
   getAgentDir,
+  ModelRuntime,
   type ModelRegistry as ModelRegistryType,
-  ModelRegistry,
-  SessionManager,
-  SettingsManager,
 } from "@earendil-works/pi-coding-agent";
+import { MOCK_REGISTRY } from "./helpers.ts";
 import { createEngine } from "../src/core/engine.ts";
 import { RlmEmitter } from "../src/tool/rlm-events.ts";
 import { loadSettings, mergeConfig } from "../src/config/settings.ts";
@@ -31,25 +28,19 @@ function capableModel(reg: ModelRegistryType) {
 
 
 async function main() {
-  const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const modelRegistry = MOCK_REGISTRY;
   const live = process.env.RLM_TEST_LIVE === "1";
   const model = live ? capableModel(modelRegistry) : cheapestModel(modelRegistry);
 
-  const loader = new DefaultResourceLoader({
-    cwd: process.cwd(),
-    agentDir: getAgentDir(),
-    extensionFactories: [rlmExtension],
-  });
-  await loader.reload();
-
+  // 0.84.x: createAgentSession no longer takes resourceLoader/sessionManager/settingsManager
+  // or an authStorage+registry pair — the SDK owns its own ModelRuntime (auth.json at agentDir)
+  // and extension loading. The global @hicaru/pi-rlm install is picked up from agentDir, which
+  // makes the suite skip via the tool-conflict branch below on hosts that already have rlm.
+  const modelRuntime = await ModelRuntime.create({ authPath: join(getAgentDir(), "auth.json") });
   const { session, extensionsResult } = await createAgentSession({
-    resourceLoader: loader,
+    agentDir: getAgentDir(),
     model,
-    authStorage,
-    modelRegistry,
-    sessionManager: SessionManager.inMemory(),
-    settingsManager: SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } }),
+    modelRuntime,
   });
 
   const installedPackagePath = join(getAgentDir(), "npm", "node_modules", "@hicaru", "pi-rlm");

--- a/pi-plugin/rlm/test/phase4.ts
+++ b/pi-plugin/rlm/test/phase4.ts
@@ -7,7 +7,8 @@
  * engine, and answer submission. Bounded to cheap models + few iterations.
  */
 
-import { AuthStorage, type ModelRegistry, ModelRegistry as MR } from "@earendil-works/pi-coding-agent";
+import { type ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { MOCK_REGISTRY } from "./helpers.ts";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { DEFAULT_CONFIG } from "../src/config/defaults.ts";
 import { createEngine } from "../src/core/engine.ts";
@@ -74,7 +75,7 @@ function rlmOnlyHandlers(opts: {
   return createSubcallHandlers({
     resolve: (_o, depth) => ({ emitter, parentId: undefined, depth, limits }),
     gates: createSubcallGates(2),
-    registry: MR.create(AuthStorage.create()),
+    registry: MOCK_REGISTRY,
     getLlmModel: () => {
       throw new Error("leaf completion must not be reached in the recursion tests");
     },
@@ -354,8 +355,7 @@ async function main() {
   const guardOk = await testPreSpawnGuard();
   if (!guardOk) process.exit(1);
 
-  const authStorage = AuthStorage.create();
-  const registry = MR.create(authStorage);
+  const registry = MOCK_REGISTRY;
   const available = registry.getAvailable();
   if (available.length > 0) {
     const fallbackModel = available[0];


### PR DESCRIPTION
# feat: pi-ai 0.84.1 compatibility — compat import, max thinking, worker leak guards, test migration

## Summary

Adapts pi-rlm 0.3.3 to run on pi-ai / pi-coding-agent **0.84.1** (upstream declares `^0.79.10`
/ `*`, but the source already targets the 0.84 model runtime), fixes two worker leak bugs,
and migrates the test suite so CI actually runs.

**Context**: `@earendil-works/pi-ai` 0.84 moved `completeSimple` behind the `/compat`
entrypoint and added the `max` thinking level; `AuthStorage` was removed from
pi-coding-agent (now `ModelRegistry` + `ModelRuntime`). The 0.3.3 source/tests were written
against 0.79.x, so on 0.84 the plugin fails to load the sub-LLM bridge and 5 core test
suites crash at import (`SyntaxError: Export named 'AuthStorage' not found`).

## Changes

### Compatibility (required to run on pi-ai 0.84)

| File | Change |
|---|---|
| `src/bridge/model.ts` | import `completeSimple` from `@earendil-works/pi-ai/compat` (0.84 entrypoint) |
| `src/config/settings.ts` | `THINKING_LEVELS` adds `max` (0.84 new level; without it `"reasoning":"max"` is dropped on load) |
| `src/ui/model-picker.ts` | picker `LEVELS` adds `max` |
|  `package.json` + `bun.lock` | peerDependencies `@earendil-works/pi-ai`/`pi-coding-agent`/`pi-tui` → `^0.84.1` (0.79.10 has no `/compat`; the old declaration was a false promise) |

### Worker leak fixes (`src/sandbox/sandbox-manager.ts`)

- **②A** dispose racing an in-flight spawn: `dispose()` now awaits `initPromise`, and the
  spawn `.then` checks `this.disposed` → disposes the worker instead of leaking it.
- **②B** `loadContext` failure: the spawned worker is now `dispose()`d before rethrowing
  (previously the child was unreachable and leaked).

### Test migration (CI currently red on 0.84)

- `test/helpers.ts`: `MOCK_REGISTRY` gains `getAvailable`/`getAll` mock rows.
- `test/phase2.ts`, `phase4.ts`, `phase-batch-gate.ts`, `phase-finish-warn.ts`:
  `ModelRegistry.create(AuthStorage.create())` → `MOCK_REGISTRY`.
- `test/phase3.ts`: `createAgentSession` switched to the 0.84 options
  (`agentDir` + `modelRuntime` via `ModelRuntime.create`), dropping
  resourceLoader/sessionManager/settingsManager wiring.
- `test/phase-llm-model.ts`: `unknown pin` assertion updated to match v0.3.2+ behavior
  (unknown saved ref pre-selects the **first real model**, not "cheapest auto" — Root
  Cause #4 guard against accidentally wiping the pin).

## Verification

- `bun run test/smoke.ts` on pi-ai 0.84.1: **all suites pass (551 checks, 0 failures)** —
  before: 515 passed / 6 failed (5× AuthStorage import crash + 1 stale assertion).
- Worker lifecycle verified in a real session: death-recreate, dispose idempotency,
  no orphan workers, `native-mode.ts` 20/20 green.
