### PR TITLE
fix(rlm): elideStalePayloads must preserve toolCall blocks in stale assistant turns

### DIFF
--- a/pi-plugin/rlm/src/core/root-context.ts
+++ b/pi-plugin/rlm/src/core/root-context.ts
@@ -109,7 +109,18 @@ function elideRange(
     if (i === lastUser) continue; // paranoia: the final user message is never touched
     if (m.role === "assistant") {
       staleAssistants -= 1; // turns AFTER this one = count minus itself
-      messages[i] = { ...m, content: [{ type: "text", text: ROOT_TURN_ELIDED_LINE }] } as RootMessage;
+      // Provider pairing invariant: Anthropic requires every tool_result to follow the
+      // assistant message carrying its tool_use; OpenAI requires each tool/function_call_output
+      // to pair with its tool_call/function_call. Eliding the toolCall blocks here orphaned the
+      // surviving toolResults and broke the request. Elide only the prose — keep toolCall blocks.
+      const toolCalls = Array.isArray(m.content)
+        ? (m.content as Array<{ type?: string }>).filter((b) => b?.type === "toolCall")
+        : [];
+      const content: unknown[] =
+        toolCalls.length > 0
+          ? [...toolCalls, { type: "text", text: ROOT_TURN_ELIDED_LINE }]
+          : [{ type: "text", text: ROOT_TURN_ELIDED_LINE }];
+      messages[i] = { ...m, content } as RootMessage;
       elided += 1;
       continue;
     }

--- a/pi-plugin/rlm/test/phase-root-context.ts
+++ b/pi-plugin/rlm/test/phase-root-context.ts
@@ -61,6 +61,30 @@ const BIG = "y".repeat(4_000);
   check("fewer turns than window ⇒ zero", none === 0);
 }
 
+// ── WS-3a regression: elision must preserve toolCall blocks (provider tool pairing) ──
+{
+  const messages: RootMessage[] = [
+    assistant("stale turn with call"),
+    toolResult("bash", "OUT ok"),
+    assistant("recent turn"),
+    user("latest ask"),
+  ];
+  // give the stale assistant a toolCall block matching the following toolResult
+  (messages[0] as { content: unknown[] }).content = [
+    { type: "text", text: "stale turn with call" },
+    { type: "toolCall", id: "tool_01", name: "bash", arguments: { cmd: "ls" } },
+  ];
+  (messages[1] as { toolCallId: string }).toolCallId = "tool_01";
+  const elided = elideStalePayloads(messages, { keepTurns: 1, elideChars: 1_500 });
+  check("stale turn elided", elided === 1, String(elided));
+  const blocks = (messages[0] as { content: { type: string }[] }).content;
+  const call = blocks.find((b) => b.type === "toolCall") as { id: string; name: string; arguments: { cmd: string } } | undefined;
+  check("toolCall block survives elision", call !== undefined, JSON.stringify(blocks));
+  check("toolCall id/name/arguments verbatim", call !== undefined && call.id === "tool_01" && call.name === "bash" && call.arguments.cmd === "ls", JSON.stringify(call));
+  check("prose still stubbed", blocks.some((b) => b.type === "text" && "text" in b && (b as { text: string }).text.length > 0));
+  check("following toolResult untouched", (messages[1] as { toolCallId: string }).toolCallId === "tool_01");
+}
+
 // ── WS-3b: sigma splice ──────────────────────────────────────────────────────────────
 {
   const tracker = RootStateTracker.fresh("splice test");


### PR DESCRIPTION
## Problem

`elideStalePayloads` in `pi-plugin/rlm/src/core/root-context.ts` replaces a stale assistant message's content wholesale with the one-line elision stub, dropping any `toolCall` blocks it contains. The following `toolResult` messages survive elision, producing orphaned tool results that providers reject:

- **Anthropic**: every `tool_result` must immediately follow the assistant message carrying its matching `tool_use` → 400 `unexpected tool_use_id` (observed in pi-subagents child sessions, where RLM runs because `@tintinweb/pi-subagents` defaults to `extensions: true`)
- **OpenAI chat-completions**: `role: "tool"` messages must respond to a preceding `tool_calls` message
- **OpenAI Responses (codex)**: `function_call_output` requires its matching `function_call` item

So this is not Anthropic-specific — any provider with tool-call pairing enforcement fails once an elided stale turn contained tool calls.

## Fix

Elide only the prose: keep `toolCall` blocks verbatim (id/name/arguments are required for a valid block) ahead of the stub text in the elided assistant message. Messages with no tool calls keep the exact previous behavior.

## Testing

- New regression block in `pi-plugin/rlm/test/phase-root-context.ts`: a stale assistant carrying a `toolCall` paired with the following `toolResult` — asserts the block survives with id/name/arguments verbatim, the prose is stubbed, and the result is untouched.
- `bun run pi-plugin/rlm/test/phase-root-context.ts` — ALL PASS
- `bun run pi-plugin/rlm/test/smoke.ts` — all suites passed
- `tsc --noEmit` clean, `eslint` clean on both touched files

Repro of the original failure before this fix: a direct minimal probe with `keepTurns=2` and a stale tool-calling assistant produced `toolCall` dropped while `toolResult.toolCallId` survived → Anthropic 400.